### PR TITLE
Add navigation markers for entity fetchers.

### DIFF
--- a/src/main/kotlin/com/netflix/dgs/plugin/navigation/DataFetcherToSchemaMarkerProvider.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/navigation/DataFetcherToSchemaMarkerProvider.kt
@@ -24,6 +24,7 @@ import com.intellij.psi.PsiIdentifier
 import com.intellij.psi.util.PsiTreeUtil
 import com.netflix.dgs.plugin.DgsConstants
 import com.netflix.dgs.plugin.DgsDataFetcher
+import com.netflix.dgs.plugin.DgsEntityFetcher
 import com.netflix.dgs.plugin.services.DgsService
 import org.jetbrains.uast.UAnnotation
 import org.jetbrains.uast.toUElement
@@ -37,18 +38,19 @@ class DataFetcherToSchemaMarkerProvider : RelatedItemLineMarkerProvider() {
 
         if (uElement is UAnnotation) {
 
-            if (DgsDataFetcher.isDataFetcherAnnotation(uElement)) {
+            if (DgsDataFetcher.isDataFetcherAnnotation(uElement) || DgsEntityFetcher.isEntityFetcherAnnotation(uElement)) {
 
                 val dgsService = element.project.getService(DgsService::class.java)
                 val dgsDataFetcher = dgsService.dgsComponentIndex.dataFetchers.find { it.psiAnnotation == element }
+                val dgsEntityFetcher = dgsService.dgsComponentIndex.entityFetchers.find { it.psiAnnotation == element }
 
-                if (dgsDataFetcher?.schemaPsi != null) {
+                if (dgsDataFetcher?.schemaPsi != null || dgsEntityFetcher?.schemaPsi != null) {
 
                     val psiIdentifier = PsiTreeUtil.findChildOfType(element, PsiIdentifier::class.java)?:element
-
+                    val target = dgsDataFetcher?.schemaPsi?: dgsEntityFetcher!!.schemaPsi
                     val builder =
                         NavigationGutterIconBuilder.create(DgsConstants.dgsIcon)
-                            .setTargets(dgsDataFetcher.schemaPsi)
+                            .setTargets(target)
                             .setTooltipText("Navigate to GraphQL schema type")
                             .createLineMarkerInfo(psiIdentifier)
 

--- a/src/main/kotlin/com/netflix/dgs/plugin/navigation/SchemaToDataFetcherMarkerProvider.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/navigation/SchemaToDataFetcherMarkerProvider.kt
@@ -20,6 +20,9 @@ import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.lang.jsgraphql.psi.GraphQLFieldDefinition
+import com.intellij.lang.jsgraphql.psi.GraphQLObjectTypeDefinition
+import com.intellij.lang.jsgraphql.psi.GraphQLObjectTypeExtensionDefinition
+import com.intellij.openapi.util.IconLoader
 import com.intellij.psi.PsiElement
 import com.netflix.dgs.plugin.DgsConstants
 import com.netflix.dgs.plugin.services.DgsService
@@ -32,14 +35,27 @@ class SchemaToDataFetcherMarkerProvider : RelatedItemLineMarkerProvider() {
         val dgsService = element.project.getService(DgsService::class.java)
 
         if (element is GraphQLFieldDefinition) {
-            val dataFetcher = dgsService.getDgsComponentIndex().dataFetchers.find { it.schemaPsi == element }
-
+            val dataFetcher = dgsService.dgsComponentIndex.dataFetchers.find { it.schemaPsi == element }
             if (dataFetcher != null) {
                 val builder =
+
                     NavigationGutterIconBuilder.create(DgsConstants.dgsIcon)
                         .setTargets(dataFetcher.psiAnnotation)
                         .setTooltipText("Navigate to DGS data fetcher")
                         .createLineMarkerInfo(element)
+
+                result.add(builder)
+            }
+        }
+
+        if (element is GraphQLObjectTypeDefinition || element is GraphQLObjectTypeExtensionDefinition) {
+            val entityFetcher = dgsService.dgsComponentIndex.entityFetchers.find { it.schemaPsi == element }
+            if (entityFetcher != null) {
+                val builder =
+                        NavigationGutterIconBuilder.create(DgsConstants.dgsIcon)
+                                .setTargets(entityFetcher.psiAnnotation)
+                                .setTooltipText("Navigate to DGS entity fetcher")
+                                .createLineMarkerInfo(element)
 
                 result.add(builder)
             }


### PR DESCRIPTION
This PR adds the DGS navigation marker for entity fetchers corresponding to any object type definitions in the schema annotated with @key.