### PR TITLE
Fixes to get unit tests working properly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
 # dgs-intellij-plugin Changelog
+## [Unreleased]
 
 ## [1.2.0]
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,9 +25,9 @@ plugins {
     // Kotlin support
     id("org.jetbrains.kotlin.jvm") version "1.5.30"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.3.0"
+    id("org.jetbrains.intellij") version "1.2.1"
     // Gradle Changelog Plugin
-    id("org.jetbrains.changelog") version "1.3.0"
+    id("org.jetbrains.changelog") version "1.2.1"
     // Gradle Qodana Plugin
     id("org.jetbrains.qodana") version "0.1.13"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
     // Gradle IntelliJ Plugin
     id("org.jetbrains.intellij") version "1.2.1"
     // Gradle Changelog Plugin
-    id("org.jetbrains.changelog") version "1.2.1"
+    id("org.jetbrains.changelog") version "1.3.0"
     // Gradle Qodana Plugin
     id("org.jetbrains.qodana") version "0.1.13"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -158,10 +158,5 @@ tasks {
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
         channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
     }
-
-    test {
-
-    }
-
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,11 @@ repositories {
     mavenCentral()
 }
 
+dependencies {
+    testImplementation(platform("org.junit:junit-bom:5.8.2"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
     pluginName.set(properties("pluginName"))
@@ -115,7 +120,11 @@ tasks {
         testLogging {
             exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
             showStandardStreams = true
+            events("passed", "skipped", "failed")
+
         }
+
+        useJUnitPlatform()
     }
 
     runPluginVerifier {
@@ -149,4 +158,10 @@ tasks {
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
         channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
     }
+
+    test {
+
+    }
+
 }
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = com.intellij.lang.jsgraphql:3.0.0, IntelliLang, com.intellij.java, org.jetbrains.kotlin, com.intellij.gradle
+platformPlugins = com.intellij.lang.jsgraphql:3.1.2, IntelliLang, com.intellij.java, org.jetbrains.kotlin, com.intellij.gradle
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 11

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = com.intellij.lang.jsgraphql:3.1.0, IntelliLang, com.intellij.java, org.jetbrains.kotlin, com.intellij.gradle
+platformPlugins = com.intellij.lang.jsgraphql:3.1.2, IntelliLang, com.intellij.java, org.jetbrains.kotlin, com.intellij.gradle
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 11

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = com.intellij.lang.jsgraphql:3.1.2, IntelliLang, com.intellij.java, org.jetbrains.kotlin, com.intellij.gradle
+platformPlugins = com.intellij.lang.jsgraphql:3.1.0, IntelliLang, com.intellij.java, org.jetbrains.kotlin, com.intellij.gradle
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 11

--- a/src/main/java/com/netflix/dgs/plugin/services/internal/DgsServiceImpl.java
+++ b/src/main/java/com/netflix/dgs/plugin/services/internal/DgsServiceImpl.java
@@ -72,6 +72,7 @@ public class DgsServiceImpl implements DgsService, Disposable {
 
     @Override
     public DgsComponentIndex getDgsComponentIndex() {
+
         if(DumbService.isDumb(project)) {
             return new DgsComponentIndex();
         }
@@ -131,7 +132,6 @@ public class DgsServiceImpl implements DgsService, Disposable {
             });
 
             cachedComponentIndex = dgsComponentIndex;
-
             ProjectView.getInstance(project).refresh();
 
             return dgsComponentIndex;

--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsComponentInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsComponentInspector.kt
@@ -95,7 +95,7 @@ class DgsComponentInspector : AbstractBaseUastLocalInspectionTool() {
                 val fqName = FqName("com.netflix.graphql.dgs.DgsComponent")
                 sourcePsi.addAnnotation(fqName)
             }
-
+            project.getService(DgsService::class.java).clearCache()
         }
     }
 }

--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsDataSimplifyingInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsDataSimplifyingInspector.kt
@@ -122,6 +122,7 @@ class DgsDataSimplifyingInspector : AbstractBaseUastLocalInspectionTool() {
                 } else {
                     (method?.sourcePsi as KtFunction).addAnnotation(FqName(annotationFQN))
                 }
+                project.getService(DgsService::class.java).clearCache()
             }
 
             descriptor.psiElement.delete()

--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsFieldSimplifyingInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsFieldSimplifyingInspector.kt
@@ -89,6 +89,7 @@ class DgsFieldSimplifyingInspector : AbstractBaseUastLocalInspectionTool() {
             }
 
             descriptor.psiElement.replace(newAnnotation)
+            project.getService(DgsService::class.java).clearCache()
         }
 
         private fun replaceField(annotationText: String): String {

--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentInspector.kt
@@ -38,14 +38,15 @@ class DgsInputArgumentInspector : AbstractBaseUastLocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
 
         return UastVisitorAdapter(object : AbstractUastNonRecursiveVisitor() {
+
             override fun visitMethod(node: UMethod): Boolean {
 
-                    if (InputArgumentUtils.hasDgsAnnotation(node) ) {
+                if (InputArgumentUtils.hasDgsAnnotation(node) ) {
                         val dgsDataAnnotation = InputArgumentUtils.getDgsAnnotation(node)
                         val dgsService = dgsDataAnnotation.project.getService(DgsService::class.java)
                         val typeDefinitionRegistry = GraphQLSchemaProvider.getInstance(dgsDataAnnotation.project).getRegistryInfo(node.navigationElement).typeDefinitionRegistry
 
-                        val dgsDataFetcher = dgsService.dgsComponentIndex.dataFetchers.find { it.psiAnnotation.toUElement() == dgsDataAnnotation.toUElement() }
+                    val dgsDataFetcher = dgsService.dgsComponentIndex.dataFetchers.find { it.psiAnnotation.toUElement() == dgsDataAnnotation.toUElement() }
                         if (dgsDataFetcher?.schemaPsi != null) {
                             val isJavaFile = dgsDataFetcher?.psiFile is PsiJavaFile
                             val arguments = (dgsDataFetcher?.schemaPsi as GraphQLFieldDefinitionImpl).argumentsDefinition?.inputValueDefinitionList
@@ -109,6 +110,7 @@ class DgsInputArgumentInspector : AbstractBaseUastLocalInspectionTool() {
                     val param = psiFactory.createParameter(it)
                         (method.sourcePsi as KtFunction).valueParameterList?.addParameter(param)
                 }
+                project.getService(DgsService::class.java).clearCache()
             }
         }
     }

--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentValidationInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentValidationInspector.kt
@@ -129,6 +129,7 @@ class DgsInputArgumentValidationInspector : AbstractBaseUastLocalInspectionTool(
                 val psiFactory = KtPsiFactory(project)
                 val param = psiFactory.createParameter(newInputArgument)
                 descriptor.psiElement.replace(param)
+                project.getService(DgsService::class.java).clearCache()
             }
         }
     }

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsComponentInspectorTest.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsComponentInspectorTest.kt
@@ -17,10 +17,11 @@
 package com.netflix.dgs.plugin
 
 import com.netflix.dgs.plugin.hints.DgsComponentInspector
+import org.junit.jupiter.api.Test
 
 class DgsComponentInspectorTest : DgsTestCase() {
 
-
+    @Test
     fun testMissingDgsComponentAnnotation() {
         myFixture.configureByFile("MissingDgsComponent.java")
         myFixture.enableInspections(DgsComponentInspector::class.java)

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsDataSimplifyingInspectorTest.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsDataSimplifyingInspectorTest.kt
@@ -17,10 +17,11 @@
 package com.netflix.dgs.plugin
 
 import com.netflix.dgs.plugin.hints.DgsDataSimplifyingInspector
+import org.junit.jupiter.api.Test
 
 class DgsDataSimplifyingInspectorTest: DgsTestCase() {
 
-
+    @Test
     fun testSimplifyQuery() {
         myFixture.configureByFile("UsingDgsDataForQuery.java")
         myFixture.enableInspections(DgsDataSimplifyingInspector::class.java)

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsEntityFetcherInspectorTest.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsEntityFetcherInspectorTest.kt
@@ -17,10 +17,11 @@
 package com.netflix.dgs.plugin
 
 import com.netflix.dgs.plugin.hints.DgsEntityFetcherInspector
+import org.junit.jupiter.api.Test
 
 class DgsEntityFetcherInspectorTest : DgsTestCase() {
 
-
+    @Test
     fun testMissingEntityFetcher() {
         myFixture.configureByFiles("FederatedEntity.graphql", "MissingDgsEntityFetcher.java")
         myFixture.enableInspections(DgsEntityFetcherInspector::class.java)

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentInspectorTest.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentInspectorTest.kt
@@ -17,11 +17,13 @@
 package com.netflix.dgs.plugin
 
 import com.netflix.dgs.plugin.hints.DgsInputArgumentInspector
+import org.junit.jupiter.api.Test
+
 // Temporarily comment tests due to flaky behavior in checkHighlighting warnings
 // Tests complain about missing java.lang.String intermittently
-/*
-class DgsInputArgumentInspectorTest : DgsTestCase() {
 
+class DgsInputArgumentInspectorTest : DgsTestCase() {
+    @Test
     fun testMissingInputArgumentSimpleTypes() {
         myFixture.configureByFiles("java/MissingSimpleTypes.java", "InputArguments.graphql")
 
@@ -31,6 +33,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("java/FixedSimpleTypes.java")
     }
 
+    @Test
     fun testMissingInputArgumentSimpleTypesForKotlin() {
         myFixture.configureByFiles("kotlin/MissingSimpleTypes.kt", "InputArguments.graphql")
 
@@ -40,6 +43,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("kotlin/FixedSimpleTypes.kt")
     }
 
+    @Test
     fun testMissingInputArgumentSimpleNonNullableTypes() {
         myFixture.configureByFiles("java/MissingSimpleNonNullableTypes.java", "InputArguments.graphql")
 
@@ -49,6 +53,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("java/FixedSimpleNonNullableTypes.java")
     }
 
+    @Test
     fun testMissingInputArgumentSimpleNonNullableTypesForKotlin() {
         myFixture.configureByFiles("kotlin/MissingSimpleNonNullableTypes.kt", "InputArguments.graphql")
 
@@ -58,6 +63,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("kotlin/FixedSimpleNonNullableTypes.kt")
     }
 
+    @Test
     fun testMissingInputArgumentEnumType() {
         myFixture.configureByFiles("java/MissingEnumType.java", "InputArguments.graphql")
 
@@ -67,6 +73,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("java/FixedEnumType.java")
     }
 
+    @Test
     fun testMissingInputArgumentEnumTypeForKotlin() {
         myFixture.configureByFiles("kotlin/MissingEnumType.kt", "InputArguments.graphql")
 
@@ -76,6 +83,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("kotlin/FixedEnumType.kt")
     }
 
+    @Test
     fun testMissingInputArgumentComplexType() {
         myFixture.configureByFiles("java/MissingComplexType.java", "InputArguments.graphql")
 
@@ -85,6 +93,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("java/FixedComplexType.java")
     }
 
+    @Test
     fun testMissingInputArgumentComplexTypeForKotlin() {
         myFixture.configureByFiles("kotlin/MissingComplexType.kt", "InputArguments.graphql")
 
@@ -94,6 +103,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("kotlin/FixedComplexType.kt")
     }
 
+    @Test
     fun testMissingInputArgumentCollectionType() {
         myFixture.configureByFiles("java/MissingCollectionType.java", "InputArguments.graphql")
 
@@ -103,6 +113,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("java/FixedCollectionType.java")
     }
 
+    @Test
     fun testMissingInputArgumentCollectionTypeForKotlin() {
         myFixture.configureByFiles("kotlin/MissingCollectionType.kt", "InputArguments.graphql")
 
@@ -112,6 +123,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("kotlin/FixedCollectionType.kt")
     }
 
+    @Test
     fun testMissingInputArgumentSimpleListTypes() {
         myFixture.configureByFiles("java/MissingSimpleListTypes.java", "InputArguments.graphql")
 
@@ -121,6 +133,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("java/FixedSimpleListTypes.java")
     }
 
+    @Test
     fun testMissingInputArgumentSimpleListTypesForKotlin() {
         myFixture.configureByFiles("kotlin/MissingSimpleListTypes.kt", "InputArguments.graphql")
 
@@ -130,6 +143,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("kotlin/FixedSimpleListTypes.kt")
     }
 
+    @Test
     fun testMissingInputArgumentScalarType() {
         myFixture.configureByFiles("java/MissingScalarType.java", "InputArguments.graphql")
 
@@ -139,6 +153,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("java/FixedScalarType.java")
     }
 
+    @Test
     fun testMissingInputArgumentScalarTypeForKotlin() {
         myFixture.configureByFiles("kotlin/MissingScalarType.kt", "InputArguments.graphql")
 
@@ -149,4 +164,3 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
     }
 
 }
-*/

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentInspectorTest.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentInspectorTest.kt
@@ -162,5 +162,4 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
         myFixture.launchAction(myFixture.findSingleIntention("You can use @InputArgument to extract parameters, e.g. @InputArgument testScalar: OffsetDateTime?"))
         myFixture.checkResultByFile("kotlin/FixedScalarType.kt")
     }
-
 }

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentValidationInspectorTest.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentValidationInspectorTest.kt
@@ -17,9 +17,10 @@
 package com.netflix.dgs.plugin
 
 import com.netflix.dgs.plugin.hints.DgsInputArgumentValidationInspector
+import org.junit.jupiter.api.Test
 
 class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
-
+    @Test
     fun testIncorrectInputArgumentSimpleTypes() {
         myFixture.configureByFiles("java/IncorrectSimpleTypes.java", "InputArguments.graphql")
 
@@ -29,6 +30,7 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("java/FixedSimpleTypes.java")
     }
 
+    @Test
     fun testIncorrectInputArgumentSimpleTypesForKotlin() {
         myFixture.configureByFiles("kotlin/IncorrectSimpleTypes.kt", "InputArguments.graphql")
 
@@ -38,6 +40,7 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("kotlin/FixedSimpleTypes.kt")
     }
 
+    @Test
     fun testIncorrectInputArgumentSimpleNonNullableTypes() {
         myFixture.configureByFiles("java/IncorrectSimpleNonNullableTypes.java", "InputArguments.graphql")
 
@@ -47,6 +50,7 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("java/FixedSimpleNonNullableTypes.java")
     }
 
+    @Test
     fun testIncorrectInputArgumentSimpleNonNullableTypesForKotlin() {
         myFixture.configureByFiles("kotlin/IncorrectSimpleNonNullableTypes.kt", "InputArguments.graphql")
 
@@ -56,6 +60,7 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("kotlin/FixedSimpleNonNullableTypes.kt")
     }
 
+    @Test
     fun testIncorrectInputArgumentEnumType() {
         myFixture.configureByFiles("java/IncorrectEnumType.java", "InputArguments.graphql")
 
@@ -65,6 +70,7 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("java/FixedEnumType.java")
     }
 
+    @Test
     fun testIncorrectInputArgumentEnumTypeForKotlin() {
         myFixture.configureByFiles("kotlin/IncorrectEnumType.kt", "InputArguments.graphql")
 
@@ -74,6 +80,7 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
         myFixture.checkResultByFile("kotlin/FixedEnumType.kt")
     }
 
+    @Test
     fun testIncorrectInputArgumentComplexTypeForKotlin() {
         myFixture.configureByFiles("kotlin/IncorrectComplexType.kt", "InputArguments.graphql")
 

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsTestCase.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsTestCase.kt
@@ -21,6 +21,8 @@ import com.intellij.openapi.module.Module
 import com.intellij.testFramework.LightProjectDescriptor
 import com.intellij.testFramework.PsiTestUtil
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import java.nio.file.Paths
 
 abstract class DgsTestCase : LightJavaCodeInsightFixtureTestCase() {
@@ -28,11 +30,18 @@ abstract class DgsTestCase : LightJavaCodeInsightFixtureTestCase() {
         return DGS_PROJECT_DESCRIPTOR
     }
 
+    @BeforeEach
     override fun setUp() {
         super.setUp()
 
         loadLibrary(project, module, "com.netflix.graphql.dgs:graphql-dgs", "graphql-dgs-4.9.2.jar")
     }
+
+    @AfterEach
+    override fun tearDown() {
+        super.tearDown()
+    }
+
 
     companion object {
         val DGS_PROJECT_DESCRIPTOR = DgsProjectDescriptor()

--- a/src/test/testdata/DgsInputArgumentInspectorTest/java/FixedSimpleListTypes.java
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/java/FixedSimpleListTypes.java
@@ -19,7 +19,7 @@ import com.netflix.graphql.dgs.DgsData;
 import com.netflix.graphql.dgs.DgsQuery;
 
 @DgsComponent
-public class MissingSimpleListType {
+public class MissingSimpleListTypes {
     @DgsQuery
     public boolean testSimpleListTypes(@InputArgument List<String> testStrings, @InputArgument List<String> testNonNullableStrings) {
         return true;

--- a/src/test/testdata/DgsInputArgumentInspectorTest/java/MissingSimpleListTypes.java
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/java/MissingSimpleListTypes.java
@@ -19,7 +19,7 @@ import com.netflix.graphql.dgs.DgsData;
 import com.netflix.graphql.dgs.DgsQuery;
 
 @DgsComponent
-public class MissingSimpleListType {
+public class MissingSimpleListTypes {
     @DgsQuery
     public boolean <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument List<String> testStrings">testSimpleListTypes<caret></weak_warning> () {
         return true;

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingCollectionType.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingCollectionType.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingCollectionType {
     @DgsQuery
-    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=TestInput) testInput: List<TestInput?>?">testCollectionType<caret></weak_warning> () : Boolean {
+    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=TestInput) testInput: List<TestInput?>?">testCollectionType</weak_warning><caret> () : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingComplexType.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingComplexType.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingComplexType {
     @DgsQuery
-    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument testInput: TestInput?">testComplexType<caret></weak_warning> () : Boolean {
+    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument testInput: TestInput?">testComplexType</weak_warning><caret> () : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingEnumType.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingEnumType.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingEnumType {
     @DgsQuery
-    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=Colors) testEnum: Colors?">testEnumType<caret></weak_warning> () : Boolean {
+    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=Colors) testEnum: Colors?">testEnumType</weak_warning><caret> () : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingScalarType.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingScalarType.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingScalarType {
     @DgsQuery
-    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument testScalar: OffsetDateTime?">testScalarType<caret></weak_warning> () : Boolean {
+    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument testScalar: OffsetDateTime?">testScalarType</weak_warning><caret> () : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingSimpleListTypes.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingSimpleListTypes.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingSimpleListType {
     @DgsQuery
-    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument testStrings: List<String?>?">testSimpleListTypes<caret></weak_warning> () : Boolean {
+    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument testStrings: List<String?>?">testSimpleListTypes</weak_warning><caret> () : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingSimpleNonNullableTypes.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingSimpleNonNullableTypes.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingSimpleNonNullableTypes {
     @DgsQuery
-    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument testString: String">testSimpleNonNullableTypes<caret></weak_warning> () : Boolean {
+    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument testString: String">testSimpleNonNullableTypes</weak_warning><caret> () : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingSimpleTypes.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingSimpleTypes.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingSimpleTypes {
     @DgsQuery
-    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument testString: String?">testSimpleTypes<caret></weak_warning>() : Boolean {
+    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument testString: String?"><caret>testSimpleTypes</weak_warning>() : Boolean {
         return true;
     }
 }


### PR DESCRIPTION
1. Enable Junit5 tests
2. Update to latest js-graphql plugin release
3. Fix bugs related to clearing cached component index after fixes during inpections
4. Enable java and kotlin tests for input argument hints