### PR TITLE
Add more unit test coverage for input argument validation, and validate argument names

### DIFF
--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentValidationInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentValidationInspector.kt
@@ -117,17 +117,6 @@ class DgsInputArgumentValidationInspector : AbstractBaseUastLocalInspectionTool(
         return param.name
     }
 
-
-    private fun getInputArgumentNameAttribute(param: UParameter) : String? {
-        val nameValue = param.getAnnotation(InputArgumentUtils.DGS_INPUT_ARGUMENT_ANNOTATION)?.findAttribute("name")?.attributeValue
-        if (nameValue != null) {
-            val jvmConstant = nameValue as JvmAnnotationConstantValue
-            if (jvmConstant.constantValue != null) {
-                return jvmConstant.constantValue as String
-            }        }
-        return null
-    }
-
     private fun hasExpectedAnnotation(graphQLInput: GraphQLInputValueDefinition, inputArgument: UParameter, typeDefinitionRegistry: TypeDefinitionRegistry, isJavaFile: Boolean) : Boolean {
         val inputArgumentAnnotation = inputArgument.getAnnotation(InputArgumentUtils.DGS_INPUT_ARGUMENT_ANNOTATION)
         if (inputArgumentAnnotation != null) {

--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentValidationInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentValidationInspector.kt
@@ -22,20 +22,24 @@ import com.intellij.lang.jsgraphql.psi.impl.GraphQLFieldDefinitionImpl
 import com.intellij.lang.jsgraphql.psi.impl.GraphQLIdentifierImpl
 import com.intellij.lang.jsgraphql.schema.GraphQLSchemaProvider
 import com.intellij.lang.jsgraphql.types.schema.idl.TypeDefinitionRegistry
+import com.intellij.lang.jvm.annotation.JvmAnnotationConstantValue
 import com.intellij.openapi.project.Project
 import com.intellij.psi.*
 import com.intellij.psi.util.parentOfType
 import com.intellij.uast.UastVisitorAdapter
+import com.intellij.util.containers.isEmpty
 import com.netflix.dgs.plugin.InputArgumentUtils
 import com.netflix.dgs.plugin.MyBundle
 import com.netflix.dgs.plugin.services.DgsService
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.resolve.calls.smartcasts.IdentifierInfo
 import org.jetbrains.kotlin.util.removeSuffixIfPresent
 import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.UParameter
 import org.jetbrains.uast.toUElement
 import org.jetbrains.uast.visitor.AbstractUastNonRecursiveVisitor
+import kotlin.streams.toList
 
 @Suppress("UElementAsPsi")
 class DgsInputArgumentValidationInspector : AbstractBaseUastLocalInspectionTool() {
@@ -53,28 +57,45 @@ class DgsInputArgumentValidationInspector : AbstractBaseUastLocalInspectionTool(
                     if (dgsDataFetcher?.schemaPsi != null) {
                         val isJavaFile = dgsDataFetcher.psiFile is PsiJavaFile
                         val arguments = (dgsDataFetcher.schemaPsi as GraphQLFieldDefinitionImpl).argumentsDefinition?.inputValueDefinitionList
-                        if (arguments != null && arguments.size > 0 && node.uastParameters.any { it.hasAnnotation(InputArgumentUtils.DGS_INPUT_ARGUMENT_ANNOTATION) }) {
-                            arguments.forEach { graphQLInputValueDefinition ->
-                                val expectedArgName = (graphQLInputValueDefinition.nameIdentifier as GraphQLIdentifierImpl).name
-                                val inputArgument = node.uastParameters.find { it.name == expectedArgName }
-                                // Enable hinting only if the argument is not a custom scalar or if it does not have the expected type
-                                if ((inputArgument != null) &&
-                                        ! InputArgumentUtils.isCustomScalarType(graphQLInputValueDefinition.type!!, typeDefinitionRegistry) &&
-                                        ! hasExpectedAnnotation(graphQLInputValueDefinition, inputArgument, typeDefinitionRegistry, isJavaFile)) {
-                                    val fixedInputArgument = InputArgumentUtils.getHintForInputArgument(graphQLInputValueDefinition, typeDefinitionRegistry, isJavaFile)
-                                    val message = MyBundle.getMessage(
-                                            "dgs.inspection.dgsinputargumentvalidation.hint",
-                                            fixedInputArgument
-                                    )
+                        if (arguments != null && arguments.size > 0) {
 
-                                    val pointer = SmartPointerManager.createPointer(node.toUElement() as UMethod)
-                                    node.identifyingElement?.let {
-                                        holder.registerProblem(inputArgument.navigationElement,
-                                                message,
-                                                ProblemHighlightType.WEAK_WARNING,
-                                                DgsInputArgumentQuickFix(pointer, fixedInputArgument, fixedInputArgument)
-                                        )
+                            // validate each argument specified in the schema against the data fetcher's input arguments
+                            node.uastParameters.stream().filter { it.hasAnnotation(InputArgumentUtils.DGS_INPUT_ARGUMENT_ANNOTATION) }.toList().forEach { iter ->
+                                val inputArgName = getInputArgumentName(iter)
+                                val schemaSearchResult = arguments?.stream()?.filter { graphQLInputValueDefinition ->
+                                    inputArgName == (graphQLInputValueDefinition.nameIdentifier as GraphQLIdentifierImpl).name }.toList()
+
+                                // if the list is empty, there is no corresponding input argument with the same name defined in the schema
+                                if (schemaSearchResult.isEmpty()) {
+                                    val inputArgumentsList = mutableListOf<String>()
+                                    var validArgumentNames = ""
+                                    // construct a list of valid argument names for the hint and fix
+                                    arguments.forEach {
+                                        validArgumentNames = validArgumentNames.plus((it.nameIdentifier as GraphQLIdentifierImpl).name).plus(", ")
                                     }
+                                    validArgumentNames = validArgumentNames.removeSuffix(", ")
+
+                                    val message = MyBundle.getMessage(
+                                            "dgs.inspection.dgsinputargumentnamevalidation.hint",
+                                            inputArgName,
+                                            validArgumentNames
+                                    )
+                                    registerProblemWithArgumentName(holder, node, iter, inputArgumentsList, message)
+                                } else {
+                                    // validate the type of the input argument
+                                    val graphQLInputValueDefinition = schemaSearchResult[0]
+                                    val inputArgument = iter
+
+                                        val fixedInputArgument = InputArgumentUtils.getHintForInputArgument(graphQLInputValueDefinition!!, typeDefinitionRegistry, isJavaFile)
+                                        // enable hinting only if the argument is not a custom scalar or if it does not have the expected type
+                                        if (!InputArgumentUtils.isCustomScalarType(graphQLInputValueDefinition.type!!, typeDefinitionRegistry)
+                                                && !hasExpectedAnnotation(graphQLInputValueDefinition, inputArgument, typeDefinitionRegistry, isJavaFile)) {
+                                            val message = MyBundle.getMessage(
+                                                    "dgs.inspection.dgsinputargumentvalidation.hint",
+                                                    fixedInputArgument
+                                            )
+                                            registerProblemWithArgumentType(holder, node, inputArgument, message, fixedInputArgument)
+                                        }
                                 }
                             }
                         }
@@ -83,6 +104,28 @@ class DgsInputArgumentValidationInspector : AbstractBaseUastLocalInspectionTool(
                 return super.visitMethod(node)
             }
         }, false)
+    }
+
+    private fun getInputArgumentName(param: UParameter) : String {
+        val nameValue = param.getAnnotation(InputArgumentUtils.DGS_INPUT_ARGUMENT_ANNOTATION)?.findAttribute("name")?.attributeValue
+        if (nameValue != null) {
+            val jvmConstant = nameValue as JvmAnnotationConstantValue
+            if (jvmConstant.constantValue != null) {
+                return jvmConstant.constantValue as String
+            }
+        }
+        return param.name
+    }
+
+
+    private fun getInputArgumentNameAttribute(param: UParameter) : String? {
+        val nameValue = param.getAnnotation(InputArgumentUtils.DGS_INPUT_ARGUMENT_ANNOTATION)?.findAttribute("name")?.attributeValue
+        if (nameValue != null) {
+            val jvmConstant = nameValue as JvmAnnotationConstantValue
+            if (jvmConstant.constantValue != null) {
+                return jvmConstant.constantValue as String
+            }        }
+        return null
     }
 
     private fun hasExpectedAnnotation(graphQLInput: GraphQLInputValueDefinition, inputArgument: UParameter, typeDefinitionRegistry: TypeDefinitionRegistry, isJavaFile: Boolean) : Boolean {
@@ -105,6 +148,26 @@ class DgsInputArgumentValidationInspector : AbstractBaseUastLocalInspectionTool(
         }
 
         return false
+    }
+
+    private fun registerProblemWithArgumentType(holder: ProblemsHolder, node: UMethod, inputArgument: UParameter, message: String, fixedInputArgument: String) {
+        val pointer = SmartPointerManager.createPointer(node.toUElement() as UMethod)
+        node.identifyingElement?.let {
+            holder.registerProblem(inputArgument.navigationElement,
+                    message,
+                    ProblemHighlightType.WEAK_WARNING,
+                    DgsInputArgumentQuickFix(pointer, fixedInputArgument, fixedInputArgument)
+            )
+        }
+    }
+
+    private fun registerProblemWithArgumentName(holder: ProblemsHolder, node: UMethod, inputArgument: UParameter, inputArgumentsList: List<String>, message: String) {
+        node.identifyingElement?.let {
+            holder.registerProblem(inputArgument.navigationElement,
+                    message,
+                    ProblemHighlightType.WEAK_WARNING
+            )
+        }
     }
 
 

--- a/src/main/resources/messages/DGSMessages.properties
+++ b/src/main/resources/messages/DGSMessages.properties
@@ -22,3 +22,4 @@ dgs.inspection.fieldvalue.simplify=The field name can be omitted if the method n
 dgs.inspection.missing.entityfetcher.annotation=An entity fetcher implementation with @DgsEntityFetcher annotation needs to be implemented for federated types with @key.
 dgs.inspection.dgsinputargument.hint=You can use @InputArgument to extract parameters, e.g. {0}
 dgs.inspection.dgsinputargumentvalidation.hint=@InputArgument type does not match the schema, expected {0}
+dgs.inspection.dgsinputargumentnamevalidation.hint=@InputArgument name {0} does not match the schema, valid argument names: [{1}]

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentValidationInspectorTest.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentValidationInspectorTest.kt
@@ -41,6 +41,26 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
     }
 
     @Test
+    fun testIncorrectInputArgumentSimpleListTypes() {
+        myFixture.configureByFiles("java/IncorrectSimpleListTypes.java", "InputArguments.graphql")
+
+        myFixture.enableInspections(DgsInputArgumentValidationInspector::class.java)
+        myFixture.checkHighlighting(true, false, true, true)
+        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument List<Integer> testIntegers"))
+        myFixture.checkResultByFile("java/FixedSimpleListTypes.java")
+    }
+
+    @Test
+    fun testIncorrectInputArgumentSimpleListTypesForKotlin() {
+        myFixture.configureByFiles("kotlin/IncorrectSimpleListTypes.kt", "InputArguments.graphql")
+
+        myFixture.enableInspections(DgsInputArgumentValidationInspector::class.java)
+        myFixture.checkHighlighting(true, false, true, true)
+        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument testIntegers: List<Int?>?"))
+        myFixture.checkResultByFile("kotlin/FixedSimpleListTypes.kt")
+    }
+
+    @Test
     fun testIncorrectInputArgumentSimpleNonNullableTypes() {
         myFixture.configureByFiles("java/IncorrectSimpleNonNullableTypes.java", "InputArguments.graphql")
 
@@ -81,6 +101,16 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
     }
 
     @Test
+    fun testIncorrectInputArgumentComplexType() {
+        myFixture.configureByFiles("java/IncorrectComplexType.java", "InputArguments.graphql")
+
+        myFixture.enableInspections(DgsInputArgumentValidationInspector::class.java)
+        myFixture.checkHighlighting(true, false, true, true)
+        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument TestInput testInput"))
+        myFixture.checkResultByFile("java/FixedComplexType.java")
+    }
+
+    @Test
     fun testIncorrectInputArgumentComplexTypeForKotlin() {
         myFixture.configureByFiles("kotlin/IncorrectComplexType.kt", "InputArguments.graphql")
 
@@ -88,5 +118,41 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
         myFixture.checkHighlighting(true, false, true, true)
         myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument testInput: TestInput?"))
         myFixture.checkResultByFile("kotlin/FixedComplexType.kt")
+    }
+
+    @Test
+    fun testIncorrectInputArgumentCollectionType() {
+        myFixture.configureByFiles("java/IncorrectCollectionType.java", "InputArguments.graphql")
+
+        myFixture.enableInspections(DgsInputArgumentValidationInspector::class.java)
+        myFixture.checkHighlighting(true, false, true, true)
+        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument (collectionType=TestInput.class) List<TestInput> testInput"))
+        myFixture.checkResultByFile("java/FixedCollectionType.java")
+    }
+
+    @Test
+    fun testIncorrectInputArgumentCollectionTypeForKotlin() {
+        myFixture.configureByFiles("kotlin/IncorrectCollectionType.kt", "InputArguments.graphql")
+
+        myFixture.enableInspections(DgsInputArgumentValidationInspector::class.java)
+        myFixture.checkHighlighting(true, false, true, true)
+        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument (collectionType=TestInput) testNonNullableInput: List<TestInput>"))
+        myFixture.checkResultByFile("kotlin/FixedCollectionType.kt")
+    }
+
+    @Test
+    fun testIncorrectInputArgumentName() {
+        myFixture.configureByFiles("java/IncorrectInputArgumentName.java", "InputArguments.graphql")
+
+        myFixture.enableInspections(DgsInputArgumentValidationInspector::class.java)
+        myFixture.checkHighlighting(true, false, true, true)
+    }
+
+    @Test
+    fun testIncorrectInputArgumentWithIncorrectNameAttribute() {
+        myFixture.configureByFiles("java/IncorrectInputArgumentNameAttribute.java", "InputArguments.graphql")
+
+        myFixture.enableInspections(DgsInputArgumentValidationInspector::class.java)
+        myFixture.checkHighlighting(true, false, true, true)
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/InputArguments.graphql
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/InputArguments.graphql
@@ -5,7 +5,8 @@ type Query {
     testEnumType(testEnum: Colors): Boolean
     testComplexType(testInput: TestInput, testNonNullableInput: TestInput!): Boolean
     testCollectionType(testInput: [TestInput], testNonNullableInput: [TestInput!]!): Boolean
-    testSimpleListTypes(testStrings: [String], testNonNullableStrings: [String!]!): Boolean
+    testSimpleListTypes(testIntegers: [Int], testFloats: [Float], testBooleans: [Boolean], testStrings: [String]): Boolean
+    testSimpleNonNullableListType(testIntegers: [Int!]!) : Boolean
     testScalarType(testScalar: DateTime): Boolean
 }
 

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/FixedCollectionType.java
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/FixedCollectionType.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import com.netflix.graphql.dgs.DgsComponent
-import com.netflix.graphql.dgs.DgsData
-import com.netflix.graphql.dgs.DgsQuery
-import com.netflix.graphql.dgs.InputArgument
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.DgsQuery;
+import com.netflix.graphql.dgs.InputArgument;
 
 @DgsComponent
-class IncorrectComplexType {
+public class IncorrectCollectionType {
     @DgsQuery
-    fun testComplexType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument testInput: TestInput?">@InputArgument testInput: Int?</weak_warning><caret>, @InputArgument testNonNullableInput: TestInput!) : Boolean {
+    public boolean testCollectionType(@InputArgument(collectionType = TestInput.class) List<TestInput> testInput) {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/FixedComplexType.java
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/FixedComplexType.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import com.netflix.graphql.dgs.DgsComponent
-import com.netflix.graphql.dgs.DgsData
-import com.netflix.graphql.dgs.DgsQuery
-import com.netflix.graphql.dgs.InputArgument
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.DgsQuery;
+import com.netflix.graphql.dgs.InputArgument;
 
 @DgsComponent
-class IncorrectComplexType {
+public class IncorrectComplexType {
     @DgsQuery
-    fun testComplexType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument testInput: TestInput?">@InputArgument testInput: Int?</weak_warning><caret>, @InputArgument testNonNullableInput: TestInput!) : Boolean {
+    public boolean testComplexType(@InputArgument TestInput testInput, @InputArgument TestInput testNonNullableInput) {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/FixedSimpleListTypes.java
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/FixedSimpleListTypes.java
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument;
 @DgsComponent
 public class IncorrectSimpleListTypes {
     @DgsQuery
-    public boolean testSimpleNonNullableTypes(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument List<Integer> testInteger">@InputArgument List<String> testInteger</weak_warning><caret>) {
+    public boolean testSimpleListTypes(@InputArgument List<Integer> testIntegers, @InputArgument List<Double> testFloats, @InputArgument List<Boolean> testBooleans, @InputArgument List<String> testStrings) {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/IncorrectCollectionType.java
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/IncorrectCollectionType.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import com.netflix.graphql.dgs.DgsComponent
-import com.netflix.graphql.dgs.DgsData
-import com.netflix.graphql.dgs.DgsQuery
-import com.netflix.graphql.dgs.InputArgument
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.DgsQuery;
+import com.netflix.graphql.dgs.InputArgument;
 
 @DgsComponent
-class IncorrectComplexType {
+public class IncorrectCollectionType {
     @DgsQuery
-    fun testComplexType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument testInput: TestInput?">@InputArgument testInput: Int?</weak_warning><caret>, @InputArgument testNonNullableInput: TestInput!) : Boolean {
+    public boolean testCollectionType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument (collectionType=TestInput.class) List<TestInput> testInput">@InputArgument List<TestInput> testInput</weak_warning><caret>) {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/IncorrectComplexType.java
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/IncorrectComplexType.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import com.netflix.graphql.dgs.DgsComponent
-import com.netflix.graphql.dgs.DgsData
-import com.netflix.graphql.dgs.DgsQuery
-import com.netflix.graphql.dgs.InputArgument
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.DgsQuery;
+import com.netflix.graphql.dgs.InputArgument;
 
 @DgsComponent
-class IncorrectComplexType {
+public class IncorrectComplexType {
     @DgsQuery
-    fun testComplexType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument testInput: TestInput?">@InputArgument testInput: Int?</weak_warning><caret>, @InputArgument testNonNullableInput: TestInput!) : Boolean {
+    public boolean testComplexType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument TestInput testInput">@InputArgument String testInput</weak_warning><caret>, @InputArgument TestInput testNonNullableInput) {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/IncorrectInputArgumentName.java
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/IncorrectInputArgumentName.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import com.netflix.graphql.dgs.DgsComponent
-import com.netflix.graphql.dgs.DgsData
-import com.netflix.graphql.dgs.DgsQuery
-import com.netflix.graphql.dgs.InputArgument
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.DgsQuery;
+import com.netflix.graphql.dgs.InputArgument;
 
 @DgsComponent
-class IncorrectComplexType {
+public class IncorrectInputArgumentName {
     @DgsQuery
-    fun testComplexType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument testInput: TestInput?">@InputArgument testInput: Int?</weak_warning><caret>, @InputArgument testNonNullableInput: TestInput!) : Boolean {
+    public boolean testSimpleTypes(<weak_warning descr="@InputArgument name testS does not match the schema, valid argument names: [testString, testInteger, testFloat, testBoolean]">@InputArgument String testS</weak_warning><caret>) {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/IncorrectInputArgumentNameAttribute.java
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/IncorrectInputArgumentNameAttribute.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import com.netflix.graphql.dgs.DgsComponent
-import com.netflix.graphql.dgs.DgsData
-import com.netflix.graphql.dgs.DgsQuery
-import com.netflix.graphql.dgs.InputArgument
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.DgsQuery;
+import com.netflix.graphql.dgs.InputArgument;
 
 @DgsComponent
-class IncorrectComplexType {
+public class IncorrectInputArgumentNameAttribute {
     @DgsQuery
-    fun testComplexType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument testInput: TestInput?">@InputArgument testInput: Int?</weak_warning><caret>, @InputArgument testNonNullableInput: TestInput!) : Boolean {
+    public boolean testSimpleTypes(<weak_warning descr="@InputArgument name testS does not match the schema, valid argument names: [testString, testInteger, testFloat, testBoolean]">@InputArgument (name="testS") String testString</weak_warning><caret>) {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/IncorrectSimpleListTypes.java
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/IncorrectSimpleListTypes.java
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument;
 @DgsComponent
 public class IncorrectSimpleListTypes {
     @DgsQuery
-    public boolean testSimpleListTypes(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument List<Integer> testInteger">@InputArgument List<String> testInteger</weak_warning><caret>) {
+    public boolean testSimpleListTypes(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument List<Integer> testIntegers">@InputArgument List<String> testIntegers</weak_warning><caret>, @InputArgument List<Double> testFloats, @InputArgument List<Boolean> testBooleans, @InputArgument List<String> testStrings) {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/FixedCollectionType.kt
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/FixedCollectionType.kt
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument
 @DgsComponent
 class IncorrectCollectionType {
     @DgsQuery
-    fun testCollectionType(@InputArgument testNonNullableInput: List<TestInput>) : Boolean {
+    fun testCollectionType(@InputArgument(collectionType = TestInput) testNonNullableInput: List<TestInput>) : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/FixedComplexType.kt
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/FixedComplexType.kt
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument
 @DgsComponent
 class IncorrectComplexType {
     @DgsQuery
-    fun testComplexType(@InputArgument testInput: TestInput?) : Boolean {
+    fun testComplexType(@InputArgument testInput: TestInput?, @InputArgument testNonNullableInput: TestInput!) : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/FixedSimpleListTypes.kt
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/FixedSimpleListTypes.kt
@@ -20,9 +20,9 @@ import com.netflix.graphql.dgs.DgsQuery
 import com.netflix.graphql.dgs.InputArgument
 
 @DgsComponent
-class IncorrectComplexType {
+class IncorrectSimpleListTypes {
     @DgsQuery
-    fun testComplexType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument testInput: TestInput?">@InputArgument testInput: Int?</weak_warning><caret>, @InputArgument testNonNullableInput: TestInput!) : Boolean {
+    fun testSimpleListTypes(@InputArgument testIntegers: List<Int?>?, @InputArgument testFloats: List<Double?>?, @InputArgument testBooleans: List<Boolean?>?, @InputArgument testStrings: List<String?>?) : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/IncorrectCollectionType.kt
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/IncorrectCollectionType.kt
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument
 @DgsComponent
 class IncorrectCollectionType {
     @DgsQuery
-    fun testCollectionType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument (collectionType=testInput) testNonNullableInput: List<testInput>">@InputArgument testNonNullableInput: List<TestInput></weak_warning><caret>) : Boolean {
+    fun testCollectionType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument (collectionType=TestInput) testNonNullableInput: List<TestInput>">@InputArgument testNonNullableInput: List<TestInput></weak_warning><caret>) : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/IncorrectSimpleListTypes.kt
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/IncorrectSimpleListTypes.kt
@@ -20,9 +20,9 @@ import com.netflix.graphql.dgs.DgsQuery
 import com.netflix.graphql.dgs.InputArgument
 
 @DgsComponent
-class IncorrectComplexType {
+class IncorrectSimpleListTypes {
     @DgsQuery
-    fun testComplexType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument testInput: TestInput?">@InputArgument testInput: Int?</weak_warning><caret>, @InputArgument testNonNullableInput: TestInput!) : Boolean {
+    fun testSimpleListTypes(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument testIntegers: List<Int?>?">@InputArgument testIntegers: List<String?>?</weak_warning><caret>, @InputArgument testFloats: List<Double?>?, @InputArgument testBooleans: List<Boolean?>?, @InputArgument testStrings: List<String?>?) : Boolean {
         return true;
     }
 }


### PR DESCRIPTION
1. Add more test coverage
2. Handle @InputArgument(name=xyz) String xyz format for validating the arg name. Previously, only the `@InputArgument String xyz` format was handled
2. Check if the argument names used with @InputArgument are valid names based on the schema, e.g. for the schema below, the corresponding data fetcher has the wrong arg name, and the validation will indicate a warning.
```
type Query {
      movies(movieId: String) : Movie
}
```
```
@DgsQuery
String movies(@InputArgument String movieIds) {
...
}
```
