### PR TITLE
Update the gradle intelliJ plugin build. 2) DGS plugin to work with 2022.1 EAP builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
     // Kotlin support
     id("org.jetbrains.kotlin.jvm") version "1.5.30"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.2.1"
+    id("org.jetbrains.intellij") version "1.5.2"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "1.3.0"
     // Gradle Qodana Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ pluginVersion = 1.2.0
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=211.0
-pluginUntilBuild=213.*
+pluginUntilBuild=221.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.


### PR DESCRIPTION
For https://github.com/Netflix/dgs-intellij-plugin/issues/27