### PR TITLE
Fix validation of kotlin collection type for enums and lists of complex types.

### DIFF
--- a/src/main/kotlin/com/netflix/dgs/plugin/DgsInputArgumentUtils.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/DgsInputArgumentUtils.kt
@@ -103,7 +103,7 @@ object InputArgumentUtils {
         if (isListType(input.type!!) || isEnumType(input.type!!, typeRegistry)) {
             val collectionType = getCollectionType(input.type!!, false)
             if (! isSimpleType(collectionType)) {
-                inputArgumentHint.append("(collectionType=$collectionType) ")
+                inputArgumentHint.append("(collectionType=$collectionType::class) ")
             }
         }
         inputArgumentHint.append(argName + ": "+ getType(input.type!!, false)  + " ")

--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentValidationInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentValidationInspector.kt
@@ -124,7 +124,7 @@ class DgsInputArgumentValidationInspector : AbstractBaseUastLocalInspectionTool(
             val expectedInputArgumentHint = InputArgumentUtils.getHintForInputArgument(graphQLInput, typeDefinitionRegistry, isJavaFile)
             if (expectedInputArgumentHint.contains("collectionType")) {
                 val expectedCollectionType = InputArgumentUtils.getCollectionType(graphQLInput.type!!, isJavaFile)
-                val inputCollectionType = inputArgumentAnnotation.findAttributeValue("collectionType")?.text?.removeSuffixIfPresent(".class")
+                val inputCollectionType = inputArgumentAnnotation.findAttributeValue("collectionType")?.text?.removeSuffixIfPresent(".class")?.removeSuffixIfPresent("::class")
                 if (expectedCollectionType != inputCollectionType) {
                     return false
                 }

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentInspectorTest.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentInspectorTest.kt
@@ -79,7 +79,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
 
         myFixture.enableInspections(DgsInputArgumentInspector::class.java)
         myFixture.checkHighlighting(true, false, true, true)
-        myFixture.launchAction(myFixture.findSingleIntention("You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=Colors) testEnum: Colors?"))
+        myFixture.launchAction(myFixture.findSingleIntention("You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=Colors::class) testEnum: Colors?"))
         myFixture.checkResultByFile("kotlin/FixedEnumType.kt")
     }
 
@@ -119,7 +119,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
 
         myFixture.enableInspections(DgsInputArgumentInspector::class.java)
         myFixture.checkHighlighting(true, false, true, true)
-        myFixture.launchAction(myFixture.findSingleIntention("You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=TestInput) testInput: List<TestInput?>?"))
+        myFixture.launchAction(myFixture.findSingleIntention("You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=TestInput::class) testInput: List<TestInput?>?"))
         myFixture.checkResultByFile("kotlin/FixedCollectionType.kt")
     }
 

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentValidationInspectorTest.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentValidationInspectorTest.kt
@@ -96,7 +96,7 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
 
         myFixture.enableInspections(DgsInputArgumentValidationInspector::class.java)
         myFixture.checkHighlighting(true, false, true, true)
-        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument (collectionType=Colors) testEnum: Colors"))
+        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument (collectionType=Colors::class) testEnum: Colors"))
         myFixture.checkResultByFile("kotlin/FixedEnumType.kt")
     }
 
@@ -136,7 +136,7 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
 
         myFixture.enableInspections(DgsInputArgumentValidationInspector::class.java)
         myFixture.checkHighlighting(true, false, true, true)
-        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument (collectionType=TestInput) testNonNullableInput: List<TestInput>"))
+        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument (collectionType=TestInput::class) testNonNullableInput: List<TestInput>"))
         myFixture.checkResultByFile("kotlin/FixedCollectionType.kt")
     }
 

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/FixedCollectionType.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/FixedCollectionType.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingCollectionType {
     @DgsQuery
-    fun testCollectionType (@InputArgument(collectionType = TestInput) testInput: List<TestInput?>?, @InputArgument(collectionType = TestInput) testNonNullableInput: List<TestInput>) : Boolean {
+    fun testCollectionType (@InputArgument(collectionType = TestInput::class) testInput: List<TestInput?>?, @InputArgument(collectionType = TestInput::class) testNonNullableInput: List<TestInput>) : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/FixedEnumType.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/FixedEnumType.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingEnumType {
     @DgsQuery
-    fun testEnumType (@InputArgument(collectionType = Colors) testEnum: Colors?) : Boolean {
+    fun testEnumType (@InputArgument(collectionType = Colors::class) testEnum: Colors?) : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingCollectionType.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingCollectionType.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingCollectionType {
     @DgsQuery
-    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=TestInput) testInput: List<TestInput?>?">testCollectionType</weak_warning><caret> () : Boolean {
+    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=TestInput::class) testInput: List<TestInput?>?">testCollectionType</weak_warning><caret> () : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingEnumType.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingEnumType.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingEnumType {
     @DgsQuery
-    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=Colors) testEnum: Colors?">testEnumType</weak_warning><caret> () : Boolean {
+    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=Colors::class) testEnum: Colors?">testEnumType</weak_warning><caret> () : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/FixedCollectionType.kt
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/FixedCollectionType.kt
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument
 @DgsComponent
 class IncorrectCollectionType {
     @DgsQuery
-    fun testCollectionType(@InputArgument(collectionType = TestInput) testNonNullableInput: List<TestInput>) : Boolean {
+    fun testCollectionType(@InputArgument(collectionType = TestInput::class) testNonNullableInput: List<TestInput>) : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/FixedEnumType.kt
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/FixedEnumType.kt
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument
 @DgsComponent
 class IncorrectEnumType {
     @DgsQuery
-    fun testEnumType(@InputArgument(collectionType = Colors) testEnum: Colors?) : Boolean {
+    fun testEnumType(@InputArgument(collectionType = Colors::class) testEnum: Colors?) : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/IncorrectCollectionType.kt
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/IncorrectCollectionType.kt
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument
 @DgsComponent
 class IncorrectCollectionType {
     @DgsQuery
-    fun testCollectionType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument (collectionType=TestInput) testNonNullableInput: List<TestInput>">@InputArgument testNonNullableInput: List<TestInput></weak_warning><caret>) : Boolean {
+    fun testCollectionType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument (collectionType=TestInput::class) testNonNullableInput: List<TestInput>">@InputArgument testNonNullableInput: List<TestInput></weak_warning><caret>) : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/IncorrectEnumType.kt
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/IncorrectEnumType.kt
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument
 @DgsComponent
 class IncorrectEnumType {
     @DgsQuery
-    fun testEnumType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument (collectionType=Colors) testEnum: Colors?">@InputArgument testEnum: Colors?</weak_warning><caret>) : Boolean {
+    fun testEnumType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument (collectionType=Colors::class) testEnum: Colors?">@InputArgument testEnum: Colors?</weak_warning><caret>) : Boolean {
         return true;
     }
 }


### PR DESCRIPTION
Collection types in kotlin need `::class` for enums and lists of complex types.
Fixes the following issues:
https://github.com/Netflix/dgs-intellij-plugin/issues/29
https://github.com/Netflix/dgs-framework/issues/936