### PR TITLE
Address NPE on DgsInputArgumentInspector on UMethod

### DIFF
--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentInspector.kt
@@ -65,14 +65,18 @@ class DgsInputArgumentInspector : AbstractBaseUastLocalInspectionTool() {
                                     "dgs.inspection.dgsinputargument.hint",
                                     inputArgumentsHint
                                 )
-
-                                val pointer = SmartPointerManager.createPointer(node.toUElement() as UMethod)
-                                node.identifyingElement?.let {
-                                    holder.registerProblem(it.navigationElement,
-                                            message,
-                                            ProblemHighlightType.WEAK_WARNING,
-                                            DgsInputArgumentQuickFix(pointer, inputArgumentsList, message)
-                                    )
+                                when(val element = node?.toUElement()){
+                                    is UMethod -> {
+                                        val pointer = SmartPointerManager.createPointer(element)
+                                        node.identifyingElement?.let {
+                                            holder.registerProblem(
+                                                it.navigationElement,
+                                                message,
+                                                ProblemHighlightType.WEAK_WARNING,
+                                                DgsInputArgumentQuickFix(pointer, inputArgumentsList, message)
+                                            )
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -83,7 +87,9 @@ class DgsInputArgumentInspector : AbstractBaseUastLocalInspectionTool() {
     }
 
 
-    class DgsInputArgumentQuickFix(private val methodPointer: SmartPsiElementPointer<UMethod>, private val newInputArguments: List<String>, private val fixName: String) : LocalQuickFix {
+    class DgsInputArgumentQuickFix(private val methodPointer: SmartPsiElementPointer<UMethod>,
+                                   private val newInputArguments: List<String>,
+                                   private val fixName: String) : LocalQuickFix {
         override fun getFamilyName(): String {
             return name
         }


### PR DESCRIPTION
Don't assume `node.toUElement` will return a none-null reference.
Have been observing the following exception.

```
Caused by: java.lang.NullPointerException: null cannot be cast to non-null type org.jetbrains.uast.UMethod
	at com.netflix.dgs.plugin.hints.DgsInputArgumentInspector$buildVisitor$1.visitMethod(DgsInputArgumentInspector.kt:69)
	at org.jetbrains.uast.UMethod$DefaultImpls.accept(UMethod.kt:42)
	at org.jetbrains.uast.kotlin.KotlinUMethod.accept(KotlinUMethod.kt:18)
	at com.intellij.uast.UastVisitorAdapter.visitElement(UastVisitorAdapter.java:32)
	at org.jetbrains.kotlin.psi.KtElementImplStub.accept(KtElementImplStub.java:52)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner.lambda$processInOrder$10(InspectionRunner.java:317)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1152)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner.lambda$processInOrder$11(InspectionRunner.java:296)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:174)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:213)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner.lambda$processInOrder$12(InspectionRunner.java:330)
	at com.intellij.util.AstLoadingFilter.forceAllowTreeLoading(AstLoadingFilter.java:159)
	at com.intellij.util.AstLoadingFilter.forceAllowTreeLoading(AstLoadingFilter.java:151)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner.lambda$processInOrder$13(InspectionRunner.java:294)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:130)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:119)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner.lambda$processInOrder$14(InspectionRunner.java:294)
	at com.intellij.concurrency.JobLauncherImpl$1MyProcessQueueTask.lambda$call$0(JobLauncherImpl.java:297)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$12(CoreProgressManager.java:608)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:683)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:639)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:607)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
	at com.intellij.concurrency.JobLauncherImpl$1MyProcessQueueTask.call(JobLauncherImpl.java:282)
	at com.intellij.concurrency.JobLauncherImpl$1MyProcessQueueTask.call(JobLauncherImpl.java:270)
	at java.base/java.util.concurrent.ForkJoinTask$AdaptedCallable.exec(ForkJoinTask.java:1448)
```