### PR TITLE
JSGraphQL to 3.1.4 and Platform Version to IU-221

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # dgs-intellij-plugin Changelog
 
 ## [Unreleased]
+### Added
+* JSGraphQL to 3.1.4 and Platform Version to IU-221
 
 ### Fixed
 * Address NPE on DgsInputArgumentInspector on UMethod.

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,15 +28,15 @@ pluginUntilBuild=221.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions = 2020.3.4, 2021.1.3, 2021.2.1
+pluginVerifierIdeVersions = 2020.3.4, 2021.1.3, 2021.2.1, 2022.1
 
 platformType = IU
-platformVersion = IU-213-EAP-SNAPSHOT
+platformVersion = IU-221-EAP-SNAPSHOT
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = com.intellij.lang.jsgraphql:3.1.2, IntelliLang, com.intellij.java, org.jetbrains.kotlin, com.intellij.gradle
+platformPlugins = com.intellij.lang.jsgraphql:3.1.4, IntelliLang, com.intellij.java, org.jetbrains.kotlin, com.intellij.gradle
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 11


### PR DESCRIPTION
Upgrade the dependency on JSGraphQL to 3.1.4 and the IntelliJ Platform Version to IU_221, include verification to 2022.1.