### PR TITLE
Address NPE on DgsInputArgumentValidationInspector:143

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 # dgs-intellij-plugin Changelog
 
-
 ## [Unreleased]
+### Fixed
+* Address NPE on DgsInputArgumentValidationInspector:143
+
+## [1.2.2]
 ### Fixed
 * Address NPE on DgsInputArgumentInspector on UMethod.
 

--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentValidationInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentValidationInspector.kt
@@ -139,22 +139,35 @@ class DgsInputArgumentValidationInspector : AbstractBaseUastLocalInspectionTool(
         return false
     }
 
-    private fun registerProblemWithArgumentType(holder: ProblemsHolder, node: UMethod, inputArgument: UParameter, message: String, fixedInputArgument: String) {
-        val pointer = SmartPointerManager.createPointer(node.toUElement() as UMethod)
-        node.identifyingElement?.let {
-            holder.registerProblem(inputArgument.navigationElement,
-                    message,
-                    ProblemHighlightType.WEAK_WARNING,
-                    DgsInputArgumentQuickFix(pointer, fixedInputArgument, fixedInputArgument)
-            )
+    private fun registerProblemWithArgumentType(
+        holder: ProblemsHolder,
+        node: UMethod,
+        inputArgument: UParameter,
+        message: String,
+        fixedInputArgument: String
+    ) {
+        when(val element = node?.toUElement()){
+            is UMethod -> {
+                val pointer = SmartPointerManager.createPointer(element)
+                node.identifyingElement?.let {
+                    holder.registerProblem(
+                        inputArgument.navigationElement,
+                        message,
+                        ProblemHighlightType.WEAK_WARNING,
+                        DgsInputArgumentQuickFix(pointer, fixedInputArgument, fixedInputArgument)
+                    )
+                }
+            }
         }
+
     }
 
     private fun registerProblemWithArgumentName(holder: ProblemsHolder, node: UMethod, inputArgument: UParameter, inputArgumentsList: List<String>, message: String) {
         node.identifyingElement?.let {
-            holder.registerProblem(inputArgument.navigationElement,
-                    message,
-                    ProblemHighlightType.WEAK_WARNING
+            holder.registerProblem(
+                inputArgument.navigationElement,
+                message,
+                ProblemHighlightType.WEAK_WARNING
             )
         }
     }


### PR DESCRIPTION
This commit addresses a NPE in DgsInputArgumentValidationInspector that assumes that a `node` will not be null.