### PR TITLE
Update to jetbrains 222

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,11 +24,11 @@ pluginVersion = 1.2.3
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=211.0
-pluginUntilBuild=221.*
+pluginUntilBuild=222.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions = 2020.3.4, 2021.1.3, 2021.2.1
+pluginVerifierIdeVersions = 2020.3.4, 2021.3.3, 2022.2
 
 platformType = IU
 platformVersion = IU-213-EAP-SNAPSHOT


### PR DESCRIPTION
IntelliJ updated to build 222 (2022.2.x) so we need to target the same. This build requires Java 17, which requires Kotlin 1.6.x.

I also updated the validator versions to have one per year.

Edit: Java 17 is not required and I have dropped those changes.