### PR TITLE
Remove validation and hints related to adding deprecated collection type.

### DIFF
--- a/src/main/kotlin/com/netflix/dgs/plugin/DgsInputArgumentUtils.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/DgsInputArgumentUtils.kt
@@ -86,12 +86,6 @@ object InputArgumentUtils {
         val argName = (input.nameIdentifier as GraphQLIdentifierImpl).name
         val inputArgumentHint = StringBuilder("@InputArgument ")
 
-        if (isListType(input.type!!) || isEnumType(input.type!!, typeRegistry)) {
-            val collectionType = getCollectionType(input.type!!, true)
-            if (!isSimpleType(collectionType)) {
-                inputArgumentHint.append("(collectionType=$collectionType.class) ")
-            }
-        }
         inputArgumentHint.append(getType(input.type!!, true) + " " + argName)
         return inputArgumentHint.toString()
 
@@ -100,12 +94,7 @@ object InputArgumentUtils {
     private fun getHintForInputArgumentInKotlin(input: GraphQLInputValueDefinition, typeRegistry: TypeDefinitionRegistry) : String {
         val argName = (input.nameIdentifier as GraphQLIdentifierImpl).name
         val inputArgumentHint = StringBuilder("@InputArgument ")
-        if (isListType(input.type!!) || isEnumType(input.type!!, typeRegistry)) {
-            val collectionType = getCollectionType(input.type!!, false)
-            if (! isSimpleType(collectionType)) {
-                inputArgumentHint.append("(collectionType=$collectionType::class) ")
-            }
-        }
+
         inputArgumentHint.append(argName + ": "+ getType(input.type!!, false)  + " ")
         return inputArgumentHint.toString()
     }
@@ -169,21 +158,6 @@ object InputArgumentUtils {
                 } else {
                     type.removeSuffixIfPresent("?")
                 }
-            }
-            else -> ""
-        }
-    }
-
-    fun getCollectionType(inputType: GraphQLType, isJavaFile: Boolean) : String {
-        return when (inputType) {
-            is GraphQLTypeName -> {
-                getRawType((inputType as PsiNamedElement).name!!, isJavaFile)
-            }
-            is GraphQLListType -> {
-                getCollectionType(inputType.type, isJavaFile)
-            }
-            is GraphQLNonNullType -> {
-                getCollectionType(inputType.type, isJavaFile)
             }
             else -> ""
         }

--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentValidationInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentValidationInspector.kt
@@ -62,7 +62,7 @@ class DgsInputArgumentValidationInspector : AbstractBaseUastLocalInspectionTool(
                             // validate each argument specified in the schema against the data fetcher's input arguments
                             node.uastParameters.stream().filter { it.hasAnnotation(InputArgumentUtils.DGS_INPUT_ARGUMENT_ANNOTATION) }.toList().forEach { iter ->
                                 val inputArgName = getInputArgumentName(iter)
-                                val schemaSearchResult = arguments?.stream()?.filter { graphQLInputValueDefinition ->
+                                val schemaSearchResult = arguments.stream().filter { graphQLInputValueDefinition ->
                                     inputArgName == (graphQLInputValueDefinition.nameIdentifier as GraphQLIdentifierImpl).name }.toList()
 
                                 // if the list is empty, there is no corresponding input argument with the same name defined in the schema
@@ -120,16 +120,6 @@ class DgsInputArgumentValidationInspector : AbstractBaseUastLocalInspectionTool(
     private fun hasExpectedAnnotation(graphQLInput: GraphQLInputValueDefinition, inputArgument: UParameter, typeDefinitionRegistry: TypeDefinitionRegistry, isJavaFile: Boolean) : Boolean {
         val inputArgumentAnnotation = inputArgument.getAnnotation(InputArgumentUtils.DGS_INPUT_ARGUMENT_ANNOTATION)
         if (inputArgumentAnnotation != null) {
-            // Check whether collection type matches, if it exists
-            val expectedInputArgumentHint = InputArgumentUtils.getHintForInputArgument(graphQLInput, typeDefinitionRegistry, isJavaFile)
-            if (expectedInputArgumentHint.contains("collectionType")) {
-                val expectedCollectionType = InputArgumentUtils.getCollectionType(graphQLInput.type!!, isJavaFile)
-                val inputCollectionType = inputArgumentAnnotation.findAttributeValue("collectionType")?.text?.removeSuffixIfPresent(".class")?.removeSuffixIfPresent("::class")
-                if (expectedCollectionType != inputCollectionType) {
-                    return false
-                }
-            }
-
             // Parse the raw type from the input argument and verify match
             val inputArgumentType = inputArgument.text.removePrefix(inputArgumentAnnotation.text).replace(inputArgument.name, "").replace(":", "").trim()
             val expectedType = InputArgumentUtils.getType(graphQLInput.type!!, isJavaFile)
@@ -159,7 +149,6 @@ class DgsInputArgumentValidationInspector : AbstractBaseUastLocalInspectionTool(
                 }
             }
         }
-
     }
 
     private fun registerProblemWithArgumentName(holder: ProblemsHolder, node: UMethod, inputArgument: UParameter, inputArgumentsList: List<String>, message: String) {

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentInspectorTest.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentInspectorTest.kt
@@ -69,7 +69,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
 
         myFixture.enableInspections(DgsInputArgumentInspector::class.java)
         myFixture.checkHighlighting(true, false, true, true)
-        myFixture.launchAction(myFixture.findSingleIntention("You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=Colors.class) Colors testEnum"))
+        myFixture.launchAction(myFixture.findSingleIntention("You can use @InputArgument to extract parameters, e.g. @InputArgument Colors testEnum"))
         myFixture.checkResultByFile("java/FixedEnumType.java")
     }
 
@@ -79,7 +79,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
 
         myFixture.enableInspections(DgsInputArgumentInspector::class.java)
         myFixture.checkHighlighting(true, false, true, true)
-        myFixture.launchAction(myFixture.findSingleIntention("You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=Colors::class) testEnum: Colors?"))
+        myFixture.launchAction(myFixture.findSingleIntention("You can use @InputArgument to extract parameters, e.g. @InputArgument testEnum: Colors?"))
         myFixture.checkResultByFile("kotlin/FixedEnumType.kt")
     }
 
@@ -109,7 +109,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
 
         myFixture.enableInspections(DgsInputArgumentInspector::class.java)
         myFixture.checkHighlighting(true, false, true, true)
-        myFixture.launchAction(myFixture.findSingleIntention("You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=TestInput.class) List<TestInput> testInput"))
+        myFixture.launchAction(myFixture.findSingleIntention("You can use @InputArgument to extract parameters, e.g. @InputArgument List<TestInput> testInput"))
         myFixture.checkResultByFile("java/FixedCollectionType.java")
     }
 
@@ -119,7 +119,7 @@ class DgsInputArgumentInspectorTest : DgsTestCase() {
 
         myFixture.enableInspections(DgsInputArgumentInspector::class.java)
         myFixture.checkHighlighting(true, false, true, true)
-        myFixture.launchAction(myFixture.findSingleIntention("You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=TestInput::class) testInput: List<TestInput?>?"))
+        myFixture.launchAction(myFixture.findSingleIntention("You can use @InputArgument to extract parameters, e.g. @InputArgument testInput: List<TestInput?>?"))
         myFixture.checkResultByFile("kotlin/FixedCollectionType.kt")
     }
 

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentValidationInspectorTest.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsInputArgumentValidationInspectorTest.kt
@@ -86,7 +86,7 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
 
         myFixture.enableInspections(DgsInputArgumentValidationInspector::class.java)
         myFixture.checkHighlighting(true, false, true, true)
-        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument (collectionType=Colors.class) Colors testEnum"))
+        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument Colors testEnum"))
         myFixture.checkResultByFile("java/FixedEnumType.java")
     }
 
@@ -96,7 +96,7 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
 
         myFixture.enableInspections(DgsInputArgumentValidationInspector::class.java)
         myFixture.checkHighlighting(true, false, true, true)
-        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument (collectionType=Colors::class) testEnum: Colors"))
+        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument testEnum: Colors?"))
         myFixture.checkResultByFile("kotlin/FixedEnumType.kt")
     }
 
@@ -126,7 +126,7 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
 
         myFixture.enableInspections(DgsInputArgumentValidationInspector::class.java)
         myFixture.checkHighlighting(true, false, true, true)
-        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument (collectionType=TestInput.class) List<TestInput> testInput"))
+        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument List<TestInput> testInput"))
         myFixture.checkResultByFile("java/FixedCollectionType.java")
     }
 
@@ -136,7 +136,7 @@ class DgsInputArgumentValidationInspectorTest : DgsTestCase() {
 
         myFixture.enableInspections(DgsInputArgumentValidationInspector::class.java)
         myFixture.checkHighlighting(true, false, true, true)
-        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument (collectionType=TestInput::class) testNonNullableInput: List<TestInput>"))
+        myFixture.launchAction(myFixture.findSingleIntention("Fix annotation to @InputArgument testNonNullableInput: List<TestInput>"))
         myFixture.checkResultByFile("kotlin/FixedCollectionType.kt")
     }
 

--- a/src/test/testdata/DgsInputArgumentInspectorTest/java/FixedCollectionType.java
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/java/FixedCollectionType.java
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 public class MissingCollectionType {
     @DgsQuery
-    public boolean testCollectionType(@InputArgument(collectionType = TestInput.class) List<TestInput> testInput, @InputArgument(collectionType = TestInput.class) List<TestInput> testNonNullableInput) {
+    public boolean testCollectionType(@InputArgument List<TestInput> testInput, @InputArgument List<TestInput> testNonNullableInput) {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/java/FixedEnumType.java
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/java/FixedEnumType.java
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 public class MissingEnumType {
     @DgsQuery
-    public boolean testEnumType(@InputArgument(collectionType = Colors.class) Colors testEnum) {
+    public boolean testEnumType(@InputArgument Colors testEnum) {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/java/MissingCollectionType.java
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/java/MissingCollectionType.java
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 public class MissingCollectionType {
     @DgsQuery
-    public boolean <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=TestInput.class) List<TestInput> testInput">testCollectionType<caret></weak_warning> () {
+    public boolean <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument List<TestInput> testInput">testCollectionType<caret></weak_warning> () {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/java/MissingEnumType.java
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/java/MissingEnumType.java
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 public class MissingEnumType {
     @DgsQuery
-    public boolean <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=Colors.class) Colors testEnum">testEnumType<caret></weak_warning> () {
+    public boolean <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument Colors testEnum">testEnumType<caret></weak_warning> () {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/FixedCollectionType.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/FixedCollectionType.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingCollectionType {
     @DgsQuery
-    fun testCollectionType (@InputArgument(collectionType = TestInput::class) testInput: List<TestInput?>?, @InputArgument(collectionType = TestInput::class) testNonNullableInput: List<TestInput>) : Boolean {
+    fun testCollectionType (@InputArgument testInput: List<TestInput?>?, @InputArgument testNonNullableInput: List<TestInput>) : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/FixedEnumType.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/FixedEnumType.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingEnumType {
     @DgsQuery
-    fun testEnumType (@InputArgument(collectionType = Colors::class) testEnum: Colors?) : Boolean {
+    fun testEnumType (@InputArgument testEnum: Colors?) : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingCollectionType.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingCollectionType.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingCollectionType {
     @DgsQuery
-    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=TestInput::class) testInput: List<TestInput?>?">testCollectionType</weak_warning><caret> () : Boolean {
+    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument testInput: List<TestInput?>?">testCollectionType</weak_warning><caret> () : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingEnumType.kt
+++ b/src/test/testdata/DgsInputArgumentInspectorTest/kotlin/MissingEnumType.kt
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQuery;
 @DgsComponent
 class MissingEnumType {
     @DgsQuery
-    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument (collectionType=Colors::class) testEnum: Colors?">testEnumType</weak_warning><caret> () : Boolean {
+    fun <weak_warning descr="You can use @InputArgument to extract parameters, e.g. @InputArgument testEnum: Colors?">testEnumType</weak_warning><caret> () : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/FixedCollectionType.java
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/FixedCollectionType.java
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument;
 @DgsComponent
 public class IncorrectCollectionType {
     @DgsQuery
-    public boolean testCollectionType(@InputArgument(collectionType = TestInput.class) List<TestInput> testInput) {
+    public boolean testCollectionType(@InputArgument List<TestInput> testInput) {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/FixedEnumType.java
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/FixedEnumType.java
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument;
 @DgsComponent
 public class IncorrectEnumType {
     @DgsQuery
-    public boolean testEnumType(@InputArgument(collectionType = Colors.class) Colors testEnum) {
+    public boolean testEnumType(@InputArgument Colors testEnum) {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/IncorrectCollectionType.java
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/IncorrectCollectionType.java
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument;
 @DgsComponent
 public class IncorrectCollectionType {
     @DgsQuery
-    public boolean testCollectionType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument (collectionType=TestInput.class) List<TestInput> testInput">@InputArgument List<TestInput> testInput</weak_warning><caret>) {
+    public boolean testCollectionType(<caret><weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument List<TestInput> testInput">@InputArgument String testInput</weak_warning>) {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/IncorrectEnumType.java
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/java/IncorrectEnumType.java
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument;
 @DgsComponent
 public class IncorrectEnumType {
     @DgsQuery
-    public boolean testEnumType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument (collectionType=Colors.class) Colors testEnum">@InputArgument String testEnum</weak_warning><caret>) {
+    public boolean testEnumType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument Colors testEnum">@InputArgument String testEnum</weak_warning><caret>) {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/FixedCollectionType.kt
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/FixedCollectionType.kt
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument
 @DgsComponent
 class IncorrectCollectionType {
     @DgsQuery
-    fun testCollectionType(@InputArgument(collectionType = TestInput::class) testNonNullableInput: List<TestInput>) : Boolean {
+    fun testCollectionType(@InputArgument testNonNullableInput: List<TestInput>) : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/FixedEnumType.kt
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/FixedEnumType.kt
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument
 @DgsComponent
 class IncorrectEnumType {
     @DgsQuery
-    fun testEnumType(@InputArgument(collectionType = Colors::class) testEnum: Colors?) : Boolean {
+    fun testEnumType(@InputArgument testEnum: Colors?) : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/IncorrectCollectionType.kt
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/IncorrectCollectionType.kt
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument
 @DgsComponent
 class IncorrectCollectionType {
     @DgsQuery
-    fun testCollectionType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument (collectionType=TestInput::class) testNonNullableInput: List<TestInput>">@InputArgument testNonNullableInput: List<TestInput></weak_warning><caret>) : Boolean {
+    fun testCollectionType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument testNonNullableInput: List<TestInput>">@InputArgument testNonNullableInput: TestInput</weak_warning><caret>) : Boolean {
         return true;
     }
 }

--- a/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/IncorrectEnumType.kt
+++ b/src/test/testdata/DgsInputArgumentValidationInspectorTest/kotlin/IncorrectEnumType.kt
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.InputArgument
 @DgsComponent
 class IncorrectEnumType {
     @DgsQuery
-    fun testEnumType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument (collectionType=Colors::class) testEnum: Colors?">@InputArgument testEnum: Colors?</weak_warning><caret>) : Boolean {
+    fun testEnumType(<weak_warning descr="@InputArgument type does not match the schema, expected @InputArgument testEnum: Colors?">@InputArgument testEnum: String</weak_warning><caret>) : Boolean {
         return true;
     }
 }


### PR DESCRIPTION
The DGS framework does not require the collection type to be specified with @InputArgument for list types and enums anymore. The plugin was still providing hints with collection type and also autofixing with collection type when missing. This PR removes that logic, so we no longer need to detect and add collection type.
