### PR TITLE
fix(DgsService): isDgsProject check dependencies on all modules

### DIFF
--- a/src/main/java/com/netflix/dgs/plugin/services/DgsService.java
+++ b/src/main/java/com/netflix/dgs/plugin/services/DgsService.java
@@ -18,6 +18,7 @@ package com.netflix.dgs.plugin.services;
 
 
 import com.intellij.openapi.project.Project;
+import org.jetbrains.kotlin.modules.Module;
 
 public interface DgsService {
     DgsComponentIndex getDgsComponentIndex();


### PR DESCRIPTION
Fixes #65 

This change fixes the logic for determining whether a project is a DGS project by checking all of the module paths, and seeing whether DGS is a dependency of any of the modules. Before this change, in cases where a project has multiple modules, the base project may not contain the DGS dependency. After this change, those projects will be supported as well.