### PR TITLE
Added DgsInputArgumentValidationInspector description

### DIFF
--- a/src/main/resources/inspectionDescriptions/DgsInputArgumentValidationInspector.html
+++ b/src/main/resources/inspectionDescriptions/DgsInputArgumentValidationInspector.html
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2023 Netflix, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<html>
+<body>
+Detects type mismatches on @InputArgument
+</body>
+</html>


### PR DESCRIPTION
IntelliJ throws an exception due to DgsInputArgumentValidationInspector not having a description.

I'm not that good with descriptions so a better message is welcome.