### PR TITLE
support IntelliJ build 233

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+## [1.3.4]
+### Fixed
+* Updated to work with IntelliJ build 233
+
 ## [1.3.3]
 ### Fixed
 * Added DgsInputArgumentValidationInspector description by @esfomeado in https://github.com/Netflix/dgs-intellij-plugin/pull/79

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,14 +24,14 @@ pluginVersion = 1.3.3
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=231.1
-pluginUntilBuild=232.*
+pluginUntilBuild=233.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions = 2023.2
+pluginVerifierIdeVersions = 2023.2, 2023.3
 
 platformType = IU
-platformVersion = 2023.1
+platformVersion = 2023.2
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION
JetBrains released IntelliJ IDEA 2023.3 Release Candidate: 

[IntelliJ IDEA 2023.3 Release Candidate Is Out | The IntelliJ IDEA Blog](https://blog.jetbrains.com/idea/2023/11/intellij-idea-2023-3-release-candidate/#:~:text=IntelliJ%20IDEA%202023.3%20Release%20Candidate%20is%20now%20available!,subscription%20to%20IntelliJ%20IDEA%20Ultimate.)

Updating upper boundary to support the IntelliJ 233 build while keeping the validation on 232 until the official release is out.