### PR TITLE
fix: @DgsEntity hint for resolvable false

### DIFF
--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsEntityFetcherInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsEntityFetcherInspector.kt
@@ -46,7 +46,16 @@ class DgsEntityFetcherInspector : LocalInspectionTool() {
                 if (element is GraphQLObjectTypeExtensionDefinition){
                     directives = element.directives
                 }
-                if (directives.any { (it.nameIdentifier as GraphQLIdentifierImpl?)?.name == "key" }) {
+                val keyDirective = directives.find { (it.nameIdentifier as GraphQLIdentifierImpl?)?.name == "key" }
+                if (keyDirective != null) {
+                    val isNotResolvable = keyDirective.arguments?.argumentList?.any { it.name == "resolvable" && it.value?.text.equals("false") } ?: false
+                    val hasExtendsDirective = directives.any { it.name == "extends" }
+
+                    // if the key directive has a resolvable argument or the extends keyword, we don't need to check for the entity fetcher
+                    if(isNotResolvable || hasExtendsDirective) {
+                        return
+                    }
+
                     // look up the corresponding entity fetcher in the type registry
                     val entityFetcher = dgsService.dgsComponentIndex.entityFetchers.find { it.schemaPsi == element }
                     if (entityFetcher == null) {

--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsEntityFetcherInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsEntityFetcherInspector.kt
@@ -49,10 +49,9 @@ class DgsEntityFetcherInspector : LocalInspectionTool() {
                 val keyDirective = directives.find { (it.nameIdentifier as GraphQLIdentifierImpl?)?.name == "key" }
                 if (keyDirective != null) {
                     val isNotResolvable = keyDirective.arguments?.argumentList?.any { it.name == "resolvable" && it.value?.text.equals("false") } ?: false
-                    val hasExtendsDirective = directives.any { it.name == "extends" }
 
-                    // if the key directive has a resolvable argument or the extends keyword, we don't need to check for the entity fetcher
-                    if(isNotResolvable || hasExtendsDirective) {
+                    // if the key directive has a resolvable argument, we don't need to check for the entity fetcher
+                    if(isNotResolvable) {
                         return
                     }
 

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsEntityFetcherInspectorTest.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsEntityFetcherInspectorTest.kt
@@ -28,4 +28,20 @@ class DgsEntityFetcherInspectorTest : DgsTestCase() {
 
         myFixture.checkHighlighting(true, false, true, true)
     }
+
+    @Test
+    fun testWithResolvableFalse() {
+        myFixture.configureByFiles("FederatedEntityWithResolvableFalse.graphql", "MissingDgsEntityFetcher.java")
+        myFixture.enableInspections(DgsEntityFetcherInspector::class.java)
+
+        myFixture.checkHighlighting()
+    }
+
+    @Test
+    fun testWithExtends() {
+        myFixture.configureByFiles("FederatedEntityWithExtends.graphql", "MissingDgsEntityFetcher.java")
+        myFixture.enableInspections(DgsEntityFetcherInspector::class.java)
+
+        myFixture.checkHighlighting()
+    }
 }

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsEntityFetcherInspectorTest.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsEntityFetcherInspectorTest.kt
@@ -36,12 +36,4 @@ class DgsEntityFetcherInspectorTest : DgsTestCase() {
 
         myFixture.checkHighlighting()
     }
-
-    @Test
-    fun testWithExtends() {
-        myFixture.configureByFiles("FederatedEntityWithExtends.graphql", "MissingDgsEntityFetcher.java")
-        myFixture.enableInspections(DgsEntityFetcherInspector::class.java)
-
-        myFixture.checkHighlighting()
-    }
 }

--- a/src/test/testdata/DgsEntityFetcherInspectorTest/FederatedEntityWithExtends.graphql
+++ b/src/test/testdata/DgsEntityFetcherInspectorTest/FederatedEntityWithExtends.graphql
@@ -1,7 +1,0 @@
-scalar _FieldSet
-directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
-directive @extends on OBJECT | INTERFACE
-type Movie @key(fields:"movieId") @extends {
-movieId: String
-budget: Int
-}

--- a/src/test/testdata/DgsEntityFetcherInspectorTest/FederatedEntityWithExtends.graphql
+++ b/src/test/testdata/DgsEntityFetcherInspectorTest/FederatedEntityWithExtends.graphql
@@ -1,0 +1,7 @@
+scalar _FieldSet
+directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
+directive @extends on OBJECT | INTERFACE
+type Movie @key(fields:"movieId") @extends {
+movieId: String
+budget: Int
+}

--- a/src/test/testdata/DgsEntityFetcherInspectorTest/FederatedEntityWithResolvableFalse.graphql
+++ b/src/test/testdata/DgsEntityFetcherInspectorTest/FederatedEntityWithResolvableFalse.graphql
@@ -1,0 +1,6 @@
+scalar _FieldSet
+directive @key(fields: _FieldSet!, resolvable: Boolean) repeatable on OBJECT | INTERFACE
+type Movie @key(fields:"movieId", resolvable: false) {
+movieId: String
+budget: Int
+}


### PR DESCRIPTION
### What?
- Filter out hint cases where the `resolvable` property in the `@key` directive is set to `false`

### Why?
- According to the Apollo Federation documentation for v2, a type with the `@key(fields: something, resolvable: false)` directive should not define a reference resolver ([reference](https://www.apollographql.com/docs/federation/federated-types/federated-directives/#arguments))
![image](https://github.com/Netflix/dgs-intellij-plugin/assets/16762967/94c26d81-7619-4591-ab5c-863e8ba8248d)
