### PR TITLE
Fix loading of schema/datafetcher navigation markers for IntelliJ 2024.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
           cache: gradle
 
       # Set environment variables
@@ -106,7 +106,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
           cache: gradle
 
       # Set environment variables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
           cache: gradle
 
       # Publish the plugin to the Marketplace

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
           cache: gradle
 
       # Run IDEA prepared for UI testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # dgs-intellij-plugin Changelog
 
 ## [Unreleased]
+## [1.4.3]
+### Fixed
+* Fix loading of navigation markers for IntelliJ 2024.3
 
 ## [1.4.2]
 ### Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ plugins {
     // Kotlin support
     id("org.jetbrains.kotlin.jvm") version "2.0.21"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij.platform") version "2.0.1"
+    id("org.jetbrains.intellij.platform") version "2.1.0"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "2.2.1"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,10 +38,10 @@ platformDownloadSources = true
 platformPlugins = com.intellij.lang.jsgraphql:243.21565.122
 platformBundledPlugins = com.intellij.java, org.jetbrains.kotlin, com.intellij.gradle
 
-# Java language level used to compile sources and to generate the files for - Java 17 is required since 2023.1
+# Java language level used to compile sources and to generate the files for - https://plugins.jetbrains.com/docs/intellij/api-changes-list-2023.html
 javaVersion = 21
 
-gradleVersion = 8.10.2
+gradleVersion = 8.11.1
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,27 +19,27 @@
 
 pluginGroup = com.netflix.graphql.dgs
 pluginName = DGS
-pluginVersion = 1.4.2
+pluginVersion = 1.4.3
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=242.1
+pluginSinceBuild=243
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions = 2024.2.1
+pluginVerifierIdeVersions = 2024.3
 
 platformType = IU
-platformVersion = 2024.2.1
+platformVersion = 2024.3
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = com.intellij.lang.jsgraphql:242.20224.155
+platformPlugins = com.intellij.lang.jsgraphql:243.21565.122
 platformBundledPlugins = com.intellij.java, org.jetbrains.kotlin, com.intellij.gradle
 
 # Java language level used to compile sources and to generate the files for - Java 17 is required since 2023.1
-javaVersion = 17
+javaVersion = 21
 
 gradleVersion = 8.10.2
 

--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentInspector.kt
@@ -19,6 +19,7 @@ package com.netflix.dgs.plugin.hints
 import com.intellij.codeInspection.*
 import com.intellij.lang.jsgraphql.psi.impl.GraphQLFieldDefinitionImpl
 import com.intellij.lang.jsgraphql.schema.GraphQLRegistryProvider
+import com.intellij.lang.jsgraphql.schema.GraphQLSchemaProvider
 import com.intellij.openapi.project.Project
 import com.intellij.psi.*
 import com.intellij.psi.util.parentOfType
@@ -44,7 +45,7 @@ class DgsInputArgumentInspector : AbstractBaseUastLocalInspectionTool() {
                 if (InputArgumentUtils.hasDgsAnnotation(node) ) {
                         val dgsDataAnnotation = InputArgumentUtils.getDgsAnnotation(node)
                         val dgsService = dgsDataAnnotation.project.getService(DgsService::class.java)
-                        val typeDefinitionRegistry = GraphQLRegistryProvider.getInstance(dgsDataAnnotation.project).getRegistryInfo(node.navigationElement).typeDefinitionRegistry
+                        val typeDefinitionRegistry = GraphQLSchemaProvider.getInstance(dgsDataAnnotation.project).getSchemaInfo(node.javaPsi).registry
 
                     val dgsDataFetcher = dgsService.dgsComponentIndex.dataFetchers.find { it.psiAnnotation.toUElement() == dgsDataAnnotation.toUElement() }
                         if (dgsDataFetcher?.schemaPsi != null) {

--- a/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentValidationInspector.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/hints/DgsInputArgumentValidationInspector.kt
@@ -21,6 +21,7 @@ import com.intellij.lang.jsgraphql.psi.GraphQLInputValueDefinition
 import com.intellij.lang.jsgraphql.psi.impl.GraphQLFieldDefinitionImpl
 import com.intellij.lang.jsgraphql.psi.impl.GraphQLIdentifierImpl
 import com.intellij.lang.jsgraphql.schema.GraphQLRegistryProvider
+import com.intellij.lang.jsgraphql.schema.GraphQLSchemaProvider
 import com.intellij.lang.jsgraphql.types.schema.idl.TypeDefinitionRegistry
 import com.intellij.lang.jvm.annotation.JvmAnnotationConstantValue
 import com.intellij.openapi.project.Project
@@ -47,7 +48,7 @@ class DgsInputArgumentValidationInspector : AbstractBaseUastLocalInspectionTool(
                 if (InputArgumentUtils.hasDgsAnnotation(node) ) {
                     val dgsDataAnnotation = InputArgumentUtils.getDgsAnnotation(node)
                     val dgsService = dgsDataAnnotation.project.getService(DgsService::class.java)
-                    val typeDefinitionRegistry = GraphQLRegistryProvider.getInstance(dgsDataAnnotation.project).getRegistryInfo(node.navigationElement).typeDefinitionRegistry
+                    val typeDefinitionRegistry = GraphQLSchemaProvider.getInstance(dgsDataAnnotation.project).getSchemaInfo(node.javaPsi).registry
 
                     val dgsDataFetcher = dgsService.dgsComponentIndex.dataFetchers.find { it.psiAnnotation.toUElement() == dgsDataAnnotation.toUElement() }
                     if (dgsDataFetcher?.schemaPsi != null) {


### PR DESCRIPTION
The jsgraphql plugin made a change [here](https://github.com/JetBrains/js-graphql-intellij-plugin/commit/a16695dae3ef50464c2330c6aba64a540a11ce0b#diff-34ed9b4b1799c15ee23f5bf943e32503a8c628616280a600509e142ba031bf23L56) to improve perf but subsequently broke pretty much all of the DGS plugin's navigation functionality as well as some of the other hints/inspections. 

This moves us to the API they introduced to effectively unlock the same functionality. Tested on a few repos and didn't find any regressions