### PR TITLE
expand DGS field resolver links for all interface derived types

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,11 +91,7 @@ intellijPlatform {
     }
     pluginVerification {
         ides {
-            select {
-                types = listOf(IntelliJPlatformType.IntellijIdeaCommunity)
-                channels = listOf(ProductRelease.Channel.RELEASE)
-                sinceBuild = properties("pluginSinceBuild")
-            }
+            ide(IntelliJPlatformType.IntellijIdeaCommunity, properties("pluginVerifierIdeVersions"))
         }
     }
     signing {

--- a/src/main/java/com/netflix/dgs/plugin/services/internal/GraphQLSchemaRegistry.java
+++ b/src/main/java/com/netflix/dgs/plugin/services/internal/GraphQLSchemaRegistry.java
@@ -25,6 +25,7 @@ import com.intellij.lang.jsgraphql.types.language.InterfaceTypeExtensionDefiniti
 import com.intellij.lang.jsgraphql.types.language.ObjectTypeDefinition;
 import com.intellij.lang.jsgraphql.types.language.ObjectTypeExtensionDefinition;
 import com.intellij.lang.jsgraphql.types.language.ScalarTypeDefinition;
+import com.intellij.lang.jsgraphql.types.language.TypeName;
 import com.intellij.lang.jsgraphql.types.schema.idl.TypeDefinitionRegistry;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
@@ -64,7 +65,7 @@ public class GraphQLSchemaRegistry {
             if (interfaceType.isPresent()) {
                 Optional<FieldDefinition> schemaField = interfaceType.get().getFieldDefinitions().stream().filter(f -> f.getName().equals(field)).findAny();
                 if (schemaField.isPresent()) {
-                    return Optional.ofNullable(GraphQLTypeDefinitionUtil.findElement(schemaField.get().getSourceLocation(), psiElement.getProject()));
+                    return Optional.ofNullable(GraphQLTypeDefinitionUtil.findElement(schemaField.get().getSourceLocation(), psiElement.getProject())).map(PsiElement::getParent);
                 }
             }
         }
@@ -124,6 +125,47 @@ public class GraphQLSchemaRegistry {
             return  Optional.ofNullable(interfaceTypeExtensionDefinitions.get(0));
         }
         return Optional.empty();
+    }
+
+    public List<String> getTypesImplementingInterface(@NotNull PsiElement psiElement, @NotNull String interfaceName) {
+        TypeDefinitionRegistry registry = getRegistry(psiElement);
+
+        // Check if the parentType is actually an interface
+        Optional<InterfaceTypeDefinition> interfaceType = getInterfaceTypeDefinition(registry, interfaceName);
+        if (!interfaceType.isPresent()) {
+            return new ArrayList<>(); // Not an interface
+        }
+
+        List<String> implementingTypes = new ArrayList<>();
+
+        // Search all object types to find those implementing this interface
+        registry.types().values().forEach(typeDefinition -> {
+            if (typeDefinition instanceof ObjectTypeDefinition) {
+                ObjectTypeDefinition objectType = (ObjectTypeDefinition) typeDefinition;
+                // Check if this type implements the interface
+                objectType.getImplements().stream()
+                    .filter(type -> type instanceof TypeName && ((TypeName) type).getName().equals(interfaceName))
+                    .findAny()
+                    .ifPresent(t -> implementingTypes.add(objectType.getName()));
+            }
+        });
+
+        // Also check type extensions
+        registry.objectTypeExtensions().values().forEach(extensions -> {
+            extensions.forEach(extension -> {
+                extension.getImplements().stream()
+                    .filter(type -> type instanceof TypeName && ((TypeName) type).getName().equals(interfaceName))
+                    .findAny()
+                    .ifPresent(t -> {
+                        // Only add if not already in the list (avoid duplicates)
+                        if (!implementingTypes.contains(extension.getName())) {
+                            implementingTypes.add(extension.getName());
+                        }
+                    });
+            });
+        });
+
+        return implementingTypes;
     }
 
     private TypeDefinitionRegistry getRegistry(@NotNull PsiElement psiElement) {

--- a/src/main/kotlin/com/netflix/dgs/plugin/services/DgsDataProcessor.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/services/DgsDataProcessor.kt
@@ -31,6 +31,7 @@ class DgsComponentProcessor(
     private val graphQLSchemaRegistry: GraphQLSchemaRegistry,
     private val dgsComponentIndex: DgsComponentIndex
 ) : Processor<UAnnotation> {
+
     override fun process(uAnnotation: UAnnotation): Boolean {
 
         val uMethod = uAnnotation.getParentOfType<UMethod>()
@@ -141,6 +142,20 @@ class DgsComponentProcessor(
                     )
 
                     dgsComponentIndex.dataFetchers.add(dgsDataFetcher)
+
+                    // If parentType is an interface, also create entries for all implementing types
+                    val implementingTypes = graphQLSchemaRegistry.getTypesImplementingInterface(uMethod, parentType)
+                    implementingTypes.forEach { implementingType ->
+                        val implDgsDataFetcher = DgsDataFetcher(
+                            implementingType,
+                            field,
+                            uMethod.sourcePsi!!,
+                            it,
+                            uAnnotation.sourcePsi?.containingFile!!,
+                            graphQLSchemaRegistry.psiForSchemaType(uMethod, implementingType, field)?.orNull()
+                        )
+                        dgsComponentIndex.dataFetchers.add(implDgsDataFetcher)
+                    }
                 }
 
             }
@@ -160,6 +175,20 @@ class DgsComponentProcessor(
                 )
 
                 dgsComponentIndex.dataFetchers.add(dgsDataFetcher)
+
+                // If parentType is an interface, also create entries for all implementing types
+                val implementingTypes = graphQLSchemaRegistry.getTypesImplementingInterface(uMethod, parentType)
+                implementingTypes.forEach { implementingType ->
+                    val implDgsDataFetcher = DgsDataFetcher(
+                        implementingType,
+                        field,
+                        uMethod.sourcePsi!!,
+                        uAnnotation.sourcePsi!!,
+                        uAnnotation.sourcePsi?.containingFile!!,
+                        graphQLSchemaRegistry.psiForSchemaType(uMethod, implementingType, field)?.orNull()
+                    )
+                    dgsComponentIndex.dataFetchers.add(implDgsDataFetcher)
+                }
             }
         }
     }


### PR DESCRIPTION
The current impl doesn't check if the type is an interface so field resolvers aren't showing correct links for all the implementations per type.  