### PR TITLE
Fix @DgsData linkage to work for implicit @Repeatable annotations as well as Explicit @DgsData.List()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+## [1.4.6]
+### Fixed
+* Code Linkage works for Implicit and Explicit @DgsData.List){})
+
 ## [1.4.5]
 ### Fixed
 * Expand DGS field resolver links for all interface derived type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## [1.4.6]
 ### Fixed
-* Code Linkage works for Implicit and Explicit @DgsData.List){})
+* Code Linkage works for Implicit and Explicit @DgsData.List
 
 ## [1.4.5]
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 pluginGroup = com.netflix.graphql.dgs
 pluginName = DGS
-pluginVersion = 1.4.5
+pluginVersion = 1.4.6
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/java/com/netflix/dgs/plugin/services/internal/DgsServiceImpl.java
+++ b/src/main/java/com/netflix/dgs/plugin/services/internal/DgsServiceImpl.java
@@ -60,6 +60,7 @@ public class DgsServiceImpl implements DgsService, Disposable {
             "DgsMutation",
             "DgsSubscription",
             "DgsData",
+            "DgsData.List",
             "DgsEntityFetcher",
             "DgsDataLoader",
             "DgsDirective",

--- a/src/main/kotlin/com/netflix/dgs/plugin/DgsDataFetcher.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/DgsDataFetcher.kt
@@ -38,6 +38,7 @@ data class DgsDataFetcher(
             "com.netflix.graphql.dgs.DgsMutation",
             "com.netflix.graphql.dgs.DgsSubscription",
             "com.netflix.graphql.dgs.DgsData",
+            "com.netflix.graphql.dgs.DgsData.List",
         )
 
         fun isDataFetcherAnnotation(annotation: PsiAnnotation): Boolean {

--- a/src/main/kotlin/com/netflix/dgs/plugin/services/DgsDataProcessor.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/services/DgsDataProcessor.kt
@@ -17,6 +17,8 @@
 package com.netflix.dgs.plugin.services
 
 import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiArrayInitializerMemberValue
+import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.Processor
 import com.intellij.util.containers.orNull
@@ -31,6 +33,9 @@ class DgsComponentProcessor(
     private val graphQLSchemaRegistry: GraphQLSchemaRegistry,
     private val dgsComponentIndex: DgsComponentIndex
 ) : Processor<UAnnotation> {
+
+    // Track methods that have been processed with @DgsData.List to avoid duplicate processing
+    private val processedDataFetcherMethods = mutableSetOf<PsiElement>()
 
     override fun process(uAnnotation: UAnnotation): Boolean {
 
@@ -124,19 +129,85 @@ class DgsComponentProcessor(
     }
 
     private fun processDataFetcher(uMethod: UMethod, uAnnotation: UAnnotation) {
-        val listAnnotation = uMethod.getAnnotation("com.netflix.graphql.dgs.DgsData.List")
-        if(listAnnotation != null) {
-            PsiTreeUtil.findChildrenOfType(listAnnotation, PsiAnnotation::class.java).forEach {
-                val parentType = DgsDataFetcher.getParentType(it)
-                val field = DgsDataFetcher.getFieldFromAnnotation(it)?:uMethod.name
+        val methodPsi = uMethod.sourcePsi!!
+
+        // Only process from @DgsData.List if the current annotation IS the list itself (explicit @DgsData.List)
+        // If the current annotation is @DgsData and a list exists, it's implicit @Repeatable - process the individual annotation
+        if (uAnnotation.qualifiedName == "com.netflix.graphql.dgs.DgsData.List") {
+            // Explicit @DgsData.List - process all annotations from the container
+            val listAnnotation = uAnnotation.sourcePsi as? PsiAnnotation
+            if (listAnnotation != null) {
+                // Check if we've already processed this method's @DgsData.List to avoid duplicates
+                if (processedDataFetcherMethods.contains(methodPsi)) {
+                    return
+                }
+                processedDataFetcherMethods.add(methodPsi)
+
+                // Access the value attribute which contains the array of @DgsData annotations
+                val valueAttribute = listAnnotation.findAttributeValue("value")
+                val annotations = when (valueAttribute) {
+                    is PsiArrayInitializerMemberValue -> {
+                        // Directly access array elements to preserve individual annotation values
+                        valueAttribute.initializers.filterIsInstance<PsiAnnotation>()
+                    }
+                    is PsiAnnotation -> {
+                        // Single annotation case
+                        listOf(valueAttribute)
+                    }
+                    else -> {
+                        // Fallback to tree search
+                        PsiTreeUtil.findChildrenOfType(listAnnotation, PsiAnnotation::class.java).toList()
+                    }
+                }
+
+                annotations.forEach {
+                    val parentType = DgsDataFetcher.getParentType(it)
+                    val field = DgsDataFetcher.getFieldFromAnnotation(it)?:uMethod.name
+
+                    //Because we use the stubs index, we might process a @DgsQuery annotation as @DgsData as well, which won't have parentType.
+                    if (parentType != null) {
+                        val dgsDataFetcher = DgsDataFetcher(
+                            parentType,
+                            field,
+                            methodPsi,
+                            it,
+                            uAnnotation.sourcePsi?.containingFile!!,
+                            graphQLSchemaRegistry.psiForSchemaType(uMethod, parentType, field)?.orNull()
+                        )
+
+                        dgsComponentIndex.dataFetchers.add(dgsDataFetcher)
+
+                        // If parentType is an interface, also create entries for all implementing types
+                        val implementingTypes = graphQLSchemaRegistry.getTypesImplementingInterface(uMethod, parentType)
+                        implementingTypes.forEach { implementingType ->
+                            val implDgsDataFetcher = DgsDataFetcher(
+                                implementingType,
+                                field,
+                                methodPsi,
+                                it,
+                                uAnnotation.sourcePsi?.containingFile!!,
+                                graphQLSchemaRegistry.psiForSchemaType(uMethod, implementingType, field)?.orNull()
+                            )
+                            dgsComponentIndex.dataFetchers.add(implDgsDataFetcher)
+                        }
+                    }
+                }
+            }
+        } else {
+            // Individual @DgsData annotation - process it directly
+            // This handles both single @DgsData and implicit @Repeatable cases
+            val annotationPsi = uAnnotation.sourcePsi as? PsiAnnotation
+            if (annotationPsi != null) {
+                val parentType = DgsDataFetcher.getParentType(annotationPsi)
+                val field = DgsDataFetcher.getFieldFromAnnotation(annotationPsi) ?: uMethod.name
 
                 //Because we use the stubs index, we might process a @DgsQuery annotation as @DgsData as well, which won't have parentType.
                 if (parentType != null) {
                     val dgsDataFetcher = DgsDataFetcher(
                         parentType,
                         field,
-                        uMethod.sourcePsi!!,
-                        it,
+                        methodPsi,
+                        annotationPsi,
                         uAnnotation.sourcePsi?.containingFile!!,
                         graphQLSchemaRegistry.psiForSchemaType(uMethod, parentType, field)?.orNull()
                     )
@@ -149,45 +220,13 @@ class DgsComponentProcessor(
                         val implDgsDataFetcher = DgsDataFetcher(
                             implementingType,
                             field,
-                            uMethod.sourcePsi!!,
-                            it,
+                            methodPsi,
+                            annotationPsi,
                             uAnnotation.sourcePsi?.containingFile!!,
                             graphQLSchemaRegistry.psiForSchemaType(uMethod, implementingType, field)?.orNull()
                         )
                         dgsComponentIndex.dataFetchers.add(implDgsDataFetcher)
                     }
-                }
-
-            }
-        } else {
-            val parentType = DgsDataFetcher.getParentType(uMethod)
-            val field = DgsDataFetcher.getField(uMethod)
-
-            //Because we use the stubs index, we might process a @DgsQuery annotation as @DgsData as well, which won't have parentType.
-            if (parentType != null) {
-                val dgsDataFetcher = DgsDataFetcher(
-                    parentType,
-                    field,
-                    uMethod.sourcePsi!!,
-                    uAnnotation.sourcePsi!!,
-                    uAnnotation.sourcePsi?.containingFile!!,
-                    graphQLSchemaRegistry.psiForSchemaType(uMethod, parentType, field)?.orNull()
-                )
-
-                dgsComponentIndex.dataFetchers.add(dgsDataFetcher)
-
-                // If parentType is an interface, also create entries for all implementing types
-                val implementingTypes = graphQLSchemaRegistry.getTypesImplementingInterface(uMethod, parentType)
-                implementingTypes.forEach { implementingType ->
-                    val implDgsDataFetcher = DgsDataFetcher(
-                        implementingType,
-                        field,
-                        uMethod.sourcePsi!!,
-                        uAnnotation.sourcePsi!!,
-                        uAnnotation.sourcePsi?.containingFile!!,
-                        graphQLSchemaRegistry.psiForSchemaType(uMethod, implementingType, field)?.orNull()
-                    )
-                    dgsComponentIndex.dataFetchers.add(implDgsDataFetcher)
                 }
             }
         }

--- a/src/main/kotlin/com/netflix/dgs/plugin/services/DgsDataProcessor.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/services/DgsDataProcessor.kt
@@ -131,23 +131,23 @@ class DgsComponentProcessor(
     private fun processDataFetcher(uMethod: UMethod, uAnnotation: UAnnotation) {
         val methodPsi = uMethod.sourcePsi!!
 
-        // Only process from @DgsData.List if the current annotation IS the list itself (explicit @DgsData.List)
-        // If the current annotation is @DgsData and a list exists, it's implicit @Repeatable - process the individual annotation
+        // Distinguish between explicit @DgsData.List and implicit @Repeatable:
+        // - Explicit: User wrote @DgsData.List({...}) - we process from the container
+        // - Implicit: User wrote multiple @DgsData annotations - Java creates container, but we process individuals
         if (uAnnotation.qualifiedName == "com.netflix.graphql.dgs.DgsData.List") {
-            // Explicit @DgsData.List - process all annotations from the container
+            // Explicit @DgsData.List - extract and process all annotations from the container
             val listAnnotation = uAnnotation.sourcePsi as? PsiAnnotation
             if (listAnnotation != null) {
-                // Check if we've already processed this method's @DgsData.List to avoid duplicates
+                // Avoid duplicate processing when stub index returns both @DgsData.List and individual annotations
                 if (processedDataFetcherMethods.contains(methodPsi)) {
                     return
                 }
                 processedDataFetcherMethods.add(methodPsi)
 
-                // Access the value attribute which contains the array of @DgsData annotations
-                val valueAttribute = listAnnotation.findAttributeValue("value")
-                val annotations = when (valueAttribute) {
+                // Extract @DgsData annotations from the value attribute array
+                val annotations = when (val valueAttribute = listAnnotation.findAttributeValue("value")) {
                     is PsiArrayInitializerMemberValue -> {
-                        // Directly access array elements to preserve individual annotation values
+                        // Array case: directly access elements to preserve individual annotation values
                         valueAttribute.initializers.filterIsInstance<PsiAnnotation>()
                     }
                     is PsiAnnotation -> {
@@ -155,79 +155,61 @@ class DgsComponentProcessor(
                         listOf(valueAttribute)
                     }
                     else -> {
-                        // Fallback to tree search
+                        // Fallback: search the tree if attribute structure is unexpected
                         PsiTreeUtil.findChildrenOfType(listAnnotation, PsiAnnotation::class.java).toList()
                     }
                 }
 
-                annotations.forEach {
-                    val parentType = DgsDataFetcher.getParentType(it)
-                    val field = DgsDataFetcher.getFieldFromAnnotation(it)?:uMethod.name
-
-                    //Because we use the stubs index, we might process a @DgsQuery annotation as @DgsData as well, which won't have parentType.
-                    if (parentType != null) {
-                        val dgsDataFetcher = DgsDataFetcher(
-                            parentType,
-                            field,
-                            methodPsi,
-                            it,
-                            uAnnotation.sourcePsi?.containingFile!!,
-                            graphQLSchemaRegistry.psiForSchemaType(uMethod, parentType, field)?.orNull()
-                        )
-
-                        dgsComponentIndex.dataFetchers.add(dgsDataFetcher)
-
-                        // If parentType is an interface, also create entries for all implementing types
-                        val implementingTypes = graphQLSchemaRegistry.getTypesImplementingInterface(uMethod, parentType)
-                        implementingTypes.forEach { implementingType ->
-                            val implDgsDataFetcher = DgsDataFetcher(
-                                implementingType,
-                                field,
-                                methodPsi,
-                                it,
-                                uAnnotation.sourcePsi?.containingFile!!,
-                                graphQLSchemaRegistry.psiForSchemaType(uMethod, implementingType, field)?.orNull()
-                            )
-                            dgsComponentIndex.dataFetchers.add(implDgsDataFetcher)
-                        }
-                    }
-                }
+                annotations.forEach { createDataFetchersForAnnotation(uMethod, methodPsi, it, uAnnotation.sourcePsi?.containingFile!!) }
             }
         } else {
-            // Individual @DgsData annotation - process it directly
+            // Individual @DgsData annotation - process directly to preserve PSI element for navigation
             // This handles both single @DgsData and implicit @Repeatable cases
             val annotationPsi = uAnnotation.sourcePsi as? PsiAnnotation
             if (annotationPsi != null) {
-                val parentType = DgsDataFetcher.getParentType(annotationPsi)
-                val field = DgsDataFetcher.getFieldFromAnnotation(annotationPsi) ?: uMethod.name
+                createDataFetchersForAnnotation(uMethod, methodPsi, annotationPsi, uAnnotation.sourcePsi?.containingFile!!)
+            }
+        }
+    }
 
-                //Because we use the stubs index, we might process a @DgsQuery annotation as @DgsData as well, which won't have parentType.
-                if (parentType != null) {
-                    val dgsDataFetcher = DgsDataFetcher(
-                        parentType,
-                        field,
-                        methodPsi,
-                        annotationPsi,
-                        uAnnotation.sourcePsi?.containingFile!!,
-                        graphQLSchemaRegistry.psiForSchemaType(uMethod, parentType, field)?.orNull()
-                    )
+    /**
+     * Creates DgsDataFetcher entries for a single @DgsData annotation.
+     * Also creates entries for all types implementing the interface if parentType is an interface.
+     */
+    private fun createDataFetchersForAnnotation(
+        uMethod: UMethod,
+        methodPsi: PsiElement,
+        annotation: PsiAnnotation,
+        containingFile: com.intellij.psi.PsiFile
+    ) {
+        val parentType = DgsDataFetcher.getParentType(annotation)
+        val field = DgsDataFetcher.getFieldFromAnnotation(annotation) ?: uMethod.name
 
-                    dgsComponentIndex.dataFetchers.add(dgsDataFetcher)
+        // Because we use the stubs index, we might process a @DgsQuery annotation as @DgsData as well, which won't have parentType.
+        if (parentType != null) {
+            val dgsDataFetcher = DgsDataFetcher(
+                parentType,
+                field,
+                methodPsi,
+                annotation,
+                containingFile,
+                graphQLSchemaRegistry.psiForSchemaType(uMethod, parentType, field)?.orNull()
+            )
 
-                    // If parentType is an interface, also create entries for all implementing types
-                    val implementingTypes = graphQLSchemaRegistry.getTypesImplementingInterface(uMethod, parentType)
-                    implementingTypes.forEach { implementingType ->
-                        val implDgsDataFetcher = DgsDataFetcher(
-                            implementingType,
-                            field,
-                            methodPsi,
-                            annotationPsi,
-                            uAnnotation.sourcePsi?.containingFile!!,
-                            graphQLSchemaRegistry.psiForSchemaType(uMethod, implementingType, field)?.orNull()
-                        )
-                        dgsComponentIndex.dataFetchers.add(implDgsDataFetcher)
-                    }
-                }
+            dgsComponentIndex.dataFetchers.add(dgsDataFetcher)
+
+            // If parentType is an interface, also create entries for all implementing types
+            val implementingTypes = graphQLSchemaRegistry.getTypesImplementingInterface(uMethod, parentType)
+            implementingTypes.forEach { implementingType ->
+                val implDgsDataFetcher = DgsDataFetcher(
+                    implementingType,
+                    field,
+                    methodPsi,
+                    annotation,
+                    containingFile,
+                    graphQLSchemaRegistry.psiForSchemaType(uMethod, implementingType, field)?.orNull()
+                )
+                dgsComponentIndex.dataFetchers.add(implDgsDataFetcher)
             }
         }
     }

--- a/src/test/kotlin/com/netflix/dgs/plugin/DgsDataMultipleAnnotationsTest.kt
+++ b/src/test/kotlin/com/netflix/dgs/plugin/DgsDataMultipleAnnotationsTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.dgs.plugin
+
+import com.intellij.openapi.application.ReadAction
+import com.netflix.dgs.plugin.services.DgsService
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for multiple @DgsData annotations on a single resolver method.
+ * This validates that when a method resolves the same field for multiple types
+ * (especially types implementing an interface), each annotation correctly links
+ * to its specific type's field in the schema.
+ */
+class DgsDataMultipleAnnotationsTest : DgsTestCase() {
+
+    /**
+     * Tests implicit @Repeatable syntax: multiple @DgsData annotations.
+     * This is the preferred syntax where Java automatically creates @DgsData.List container.
+     */
+    @Test
+    fun testImplicitRepeatableAnnotations() {
+        fixture.configureByFiles("schema.graphql", "MultipleAnnotationsDataFetcher.java")
+
+        ReadAction.run<Exception> {
+            val dgsService = fixture.project.getService(DgsService::class.java)
+            val dataFetchers = dgsService.dgsComponentIndex.dataFetchers
+
+            // Test title field - should have 2 data fetchers from implicit @Repeatable
+            val titleFetchers = dataFetchers.filter { it.field == "title" }
+            assertEquals(2, titleFetchers.size, "Expected 2 data fetchers for 'title' field")
+
+            // Verify Movie.title links correctly
+            val movieTitleFetcher = titleFetchers.find { it.parentType == "Movie" }
+            assertNotNull(movieTitleFetcher, "Should have data fetcher for Movie.title")
+            assertEquals("title", movieTitleFetcher!!.field)
+            assertEquals("Movie", movieTitleFetcher.parentType)
+            assertNotNull(movieTitleFetcher.schemaPsi, "Movie.title should link to schema")
+
+            // Verify Show.title links correctly
+            val showTitleFetcher = titleFetchers.find { it.parentType == "Show" }
+            assertNotNull(showTitleFetcher, "Should have data fetcher for Show.title")
+            assertEquals("title", showTitleFetcher!!.field)
+            assertEquals("Show", showTitleFetcher.parentType)
+            assertNotNull(showTitleFetcher.schemaPsi, "Show.title should link to schema")
+
+            // Both should reference the same method
+            assertEquals(movieTitleFetcher.psiMethod, showTitleFetcher.psiMethod,
+                "Both data fetchers should reference the same method")
+
+            // Verify each annotation PSI is distinct (critical for correct navigation)
+            assertNotEquals(movieTitleFetcher.psiAnnotation, showTitleFetcher.psiAnnotation,
+                "Each @DgsData annotation should have its own distinct PSI element")
+
+            // Test contentAdvisory field - should have 4 data fetchers from implicit @Repeatable
+            val advisoryFetchers = dataFetchers.filter { it.field == "contentAdvisory" }
+            assertEquals(4, advisoryFetchers.size, "Expected 4 data fetchers for 'contentAdvisory' field")
+
+            // Verify each type has correct linkage
+            val types = listOf("Movie", "Show", "Season", "Episode")
+            types.forEach { typeName ->
+                val fetcher = advisoryFetchers.find { it.parentType == typeName }
+                assertNotNull(fetcher, "Should have data fetcher for $typeName.contentAdvisory")
+                assertEquals("contentAdvisory", fetcher!!.field)
+                assertEquals(typeName, fetcher.parentType)
+                assertNotNull(fetcher.schemaPsi, "$typeName.contentAdvisory should link to schema")
+            }
+
+            // All should reference the same method
+            val methodReferences = advisoryFetchers.map { it.psiMethod }.distinct()
+            assertEquals(1, methodReferences.size, "All data fetchers should reference the same method")
+        }
+    }
+
+    /**
+     * Tests explicit @DgsData.List syntax.
+     * This is an alternative syntax that should work identically to implicit @Repeatable.
+     */
+    @Test
+    fun testExplicitDgsDataList() {
+        fixture.configureByFiles("schema.graphql", "ExplicitListDataFetcher.java")
+
+        ReadAction.run<Exception> {
+            val dgsService = fixture.project.getService(DgsService::class.java)
+            val dataFetchers = dgsService.dgsComponentIndex.dataFetchers
+
+            // Test title field - should have 2 data fetchers from explicit @DgsData.List
+            val titleFetchers = dataFetchers.filter { it.field == "title" }
+            assertEquals(2, titleFetchers.size, "Expected 2 data fetchers for 'title' field")
+
+            // Verify Movie.title
+            val movieFetcher = titleFetchers.find { it.parentType == "Movie" }
+            assertNotNull(movieFetcher, "Should have data fetcher for Movie.title")
+            assertEquals("title", movieFetcher!!.field)
+            assertEquals("Movie", movieFetcher.parentType)
+            assertNotNull(movieFetcher.schemaPsi, "Movie.title should link to schema")
+
+            // Verify Show.title
+            val showFetcher = titleFetchers.find { it.parentType == "Show" }
+            assertNotNull(showFetcher, "Should have data fetcher for Show.title")
+            assertEquals("title", showFetcher!!.field)
+            assertEquals("Show", showFetcher.parentType)
+            assertNotNull(showFetcher.schemaPsi, "Show.title should link to schema")
+
+            // Both should reference the same method
+            assertEquals(movieFetcher.psiMethod, showFetcher.psiMethod,
+                "Both data fetchers should reference the same method")
+
+            // Test contentAdvisory field - should have 4 data fetchers
+            val advisoryFetchers = dataFetchers.filter { it.field == "contentAdvisory" }
+            assertEquals(4, advisoryFetchers.size, "Expected 4 data fetchers for 'contentAdvisory' field")
+
+            // Verify each type has correct linkage
+            val types = listOf("Movie", "Show", "Season", "Episode")
+            types.forEach { typeName ->
+                val fetcher = advisoryFetchers.find { it.parentType == typeName }
+                assertNotNull(fetcher, "Should have data fetcher for $typeName.contentAdvisory")
+                assertEquals("contentAdvisory", fetcher!!.field)
+                assertEquals(typeName, fetcher.parentType)
+                assertNotNull(fetcher.schemaPsi, "$typeName.contentAdvisory should link to schema")
+            }
+
+            // All should reference the same method
+            val methodReferences = advisoryFetchers.map { it.psiMethod }.distinct()
+            assertEquals(1, methodReferences.size, "All data fetchers should reference the same method")
+        }
+    }
+}

--- a/src/test/testdata/DgsDataMultipleAnnotationsTest/ExplicitListDataFetcher.java
+++ b/src/test/testdata/DgsDataMultipleAnnotationsTest/ExplicitListDataFetcher.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+
+@DgsComponent
+public class ExplicitListDataFetcher {
+
+    // Using explicit @DgsData.List - same functionality as implicit @Repeatable
+    // These should each link to their specific type's field in the schema
+    @DgsData.List({
+        @DgsData(parentType = "Movie", field = "title"),
+        @DgsData(parentType = "Show", field = "title")
+    })
+    public String title() {
+        return "Sample Title";
+    }
+
+    // Using explicit @DgsData.List with four types
+    @DgsData.List({
+        @DgsData(parentType = "Movie", field = "contentAdvisory"),
+        @DgsData(parentType = "Show", field = "contentAdvisory"),
+        @DgsData(parentType = "Season", field = "contentAdvisory"),
+        @DgsData(parentType = "Episode", field = "contentAdvisory")
+    })
+    public Advisory contentAdvisory() {
+        return new Advisory();
+    }
+
+    static class Advisory {
+        public String rating;
+    }
+}

--- a/src/test/testdata/DgsDataMultipleAnnotationsTest/MultipleAnnotationsDataFetcher.java
+++ b/src/test/testdata/DgsDataMultipleAnnotationsTest/MultipleAnnotationsDataFetcher.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+
+@DgsComponent
+public class MultipleAnnotationsDataFetcher {
+
+    // Using implicit @Repeatable - multiple @DgsData annotations
+    // These should each link to their specific type's field in the schema
+    @DgsData(parentType = "Movie", field = "title")
+    @DgsData(parentType = "Show", field = "title")
+    public String title() {
+        return "Sample Title";
+    }
+
+    // Using implicit @Repeatable with four types
+    @DgsData(parentType = "Movie", field = "contentAdvisory")
+    @DgsData(parentType = "Show", field = "contentAdvisory")
+    @DgsData(parentType = "Season", field = "contentAdvisory")
+    @DgsData(parentType = "Episode", field = "contentAdvisory")
+    public Advisory contentAdvisory() {
+        return new Advisory();
+    }
+
+    static class Advisory {
+        public String rating;
+    }
+}

--- a/src/test/testdata/DgsDataMultipleAnnotationsTest/schema.graphql
+++ b/src/test/testdata/DgsDataMultipleAnnotationsTest/schema.graphql
@@ -1,0 +1,32 @@
+interface Video {
+    title: String
+    contentAdvisory: Advisory
+}
+
+type Movie implements Video {
+    title: String
+    contentAdvisory: Advisory
+    director: String
+}
+
+type Show implements Video {
+    title: String
+    contentAdvisory: Advisory
+    episodes: Int
+}
+
+type Season implements Video {
+    title: String
+    contentAdvisory: Advisory
+    seasonNumber: Int
+}
+
+type Episode implements Video {
+    title: String
+    contentAdvisory: Advisory
+    episodeNumber: Int
+}
+
+type Advisory {
+    rating: String
+}


### PR DESCRIPTION
The current code creates a link on the first annotation is sees.  This change splits the processing to handle implicit/explicit lists separately to link the correct PSI element node.  Also added tests to verify both cases.  