### PR TITLE
Fix schema datafetcher/resolver links to the exact schema type/field, ignoring comments

### DIFF
--- a/src/main/kotlin/com/netflix/dgs/plugin/navigation/DataFetcherToSchemaMarkerProvider.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/navigation/DataFetcherToSchemaMarkerProvider.kt
@@ -19,7 +19,6 @@ package com.netflix.dgs.plugin.navigation
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
-import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.netflix.dgs.plugin.DgsConstants
@@ -50,8 +49,7 @@ class DataFetcherToSchemaMarkerProvider : RelatedItemLineMarkerProvider() {
 
                 if (dgsDataFetcher?.schemaPsi != null || dgsEntityFetcher?.schemaPsi != null) {
 
-                    // Use nameReferenceElement for annotations to get the annotation name identifier, ignoring any preceding comments
-                    val psiLeaf = (element as? PsiAnnotation)?.nameReferenceElement ?: PsiTreeUtil.getDeepestFirst(element)
+                    val psiLeaf = PsiTreeUtil.getDeepestFirst(element)
                     val target = dgsDataFetcher?.schemaPsi?: dgsEntityFetcher!!.schemaPsi
                     val builder =
                         NavigationGutterIconBuilder.create(DgsConstants.dgsIcon)

--- a/src/main/kotlin/com/netflix/dgs/plugin/navigation/DataFetcherToSchemaMarkerProvider.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/navigation/DataFetcherToSchemaMarkerProvider.kt
@@ -19,6 +19,7 @@ package com.netflix.dgs.plugin.navigation
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
+import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.netflix.dgs.plugin.DgsConstants
@@ -49,7 +50,8 @@ class DataFetcherToSchemaMarkerProvider : RelatedItemLineMarkerProvider() {
 
                 if (dgsDataFetcher?.schemaPsi != null || dgsEntityFetcher?.schemaPsi != null) {
 
-                    val psiLeaf = PsiTreeUtil.getDeepestFirst(element)
+                    // Use nameReferenceElement for annotations to get the annotation name identifier, ignoring any preceding comments
+                    val psiLeaf = (element as? PsiAnnotation)?.nameReferenceElement ?: PsiTreeUtil.getDeepestFirst(element)
                     val target = dgsDataFetcher?.schemaPsi?: dgsEntityFetcher!!.schemaPsi
                     val builder =
                         NavigationGutterIconBuilder.create(DgsConstants.dgsIcon)

--- a/src/main/kotlin/com/netflix/dgs/plugin/navigation/SchemaToDataFetcherMarkerProvider.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/navigation/SchemaToDataFetcherMarkerProvider.kt
@@ -20,6 +20,7 @@ import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.lang.jsgraphql.psi.*
+import com.intellij.lang.jsgraphql.psi.impl.GraphQLIdentifierImpl
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.netflix.dgs.plugin.DgsConstants
@@ -34,7 +35,8 @@ class SchemaToDataFetcherMarkerProvider : RelatedItemLineMarkerProvider() {
         if(!dgsService.isDgsProject(element.project)) {
             return
         }
-        val psiLeaf = PsiTreeUtil.getDeepestFirst(element)
+        // Find the identifier child element to pin the gutter icon, ignoring any preceding comments
+        val psiLeaf = PsiTreeUtil.findChildOfType(element, GraphQLIdentifierImpl::class.java) ?: PsiTreeUtil.getDeepestFirst(element)
 
         val iconBuilder = when (element) {
             is GraphQLFieldDefinition -> {


### PR DESCRIPTION
<img width="838" height="124" alt="image" src="https://github.com/user-attachments/assets/f1fc35fc-a935-4e67-8679-fc27a4a4c49a" />

Current impl links it to the PSI element, which includes comments.  Fix ignores comments.