### PR TITLE
Fix Kotlin @DgsData fetchers never indexed due to PsiAnnotation cast

### DIFF
--- a/src/main/kotlin/com/netflix/dgs/plugin/DgsDataFetcher.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/DgsDataFetcher.kt
@@ -73,7 +73,7 @@ data class DgsDataFetcher(
                 ?: throw IllegalArgumentException("Method ${method.name} is not a data fetcher"))
 
         fun getFieldFromAnnotation(annotation: UAnnotation): String? {
-            return annotation.findAttributeValue("field")?.evaluateString()
+            return annotation.findAttributeValue("field")?.evaluateString()?.takeIf { it.isNotEmpty() }
         }
 
         fun getFieldFromAnnotation(annotation: PsiAnnotation): String? {

--- a/src/main/kotlin/com/netflix/dgs/plugin/DgsDataFetcher.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/DgsDataFetcher.kt
@@ -49,15 +49,18 @@ data class DgsDataFetcher(
             return annotationQualifiedNames.contains(annotation.qualifiedName)
         }
 
-        fun getParentType(annotation: PsiAnnotation): String? {
+        fun getParentType(annotation: UAnnotation): String? {
             return when (annotation.qualifiedName) {
                 "com.netflix.graphql.dgs.DgsQuery" -> "Query"
                 "com.netflix.graphql.dgs.DgsMutation" -> "Mutation"
                 "com.netflix.graphql.dgs.DgsSubscription" -> "Subscription"
-                "com.netflix.graphql.dgs.DgsData" -> (annotation.toUElement() as UAnnotation).findAttributeValue("parentType")
-                    ?.evaluateString()
+                "com.netflix.graphql.dgs.DgsData" -> annotation.findAttributeValue("parentType")?.evaluateString()
                 else -> throw IllegalArgumentException("Annotation ${annotation.qualifiedName} is not a data fetcher annotation")
             }
+        }
+
+        fun getParentType(annotation: PsiAnnotation): String? {
+            return (annotation.toUElement() as? UAnnotation)?.let { getParentType(it) }
         }
 
         fun getParentType(method: PsiMethod): String? {
@@ -69,11 +72,12 @@ data class DgsDataFetcher(
             (method.annotations.find { a -> isDataFetcherAnnotation(a) }
                 ?: throw IllegalArgumentException("Method ${method.name} is not a data fetcher"))
 
+        fun getFieldFromAnnotation(annotation: UAnnotation): String? {
+            return annotation.findAttributeValue("field")?.evaluateString()
+        }
+
         fun getFieldFromAnnotation(annotation: PsiAnnotation): String? {
-            return if (annotation.hasAttribute("field")) {
-                (annotation.toUElement() as UAnnotation).findAttributeValue("field")?.evaluateString()
-            }
-            else null
+            return (annotation.toUElement() as? UAnnotation)?.let { getFieldFromAnnotation(it) }
         }
 
         fun getField(method: PsiMethod): String {

--- a/src/main/kotlin/com/netflix/dgs/plugin/navigation/DgsSymbolContributor.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/navigation/DgsSymbolContributor.kt
@@ -22,11 +22,12 @@ import com.intellij.navigation.NavigationItem
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
-import com.intellij.psi.util.parentOfType
 import com.netflix.dgs.plugin.DgsConstants
 import com.netflix.dgs.plugin.services.DgsService
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.getParentOfType
+import org.jetbrains.uast.toUElement
 import javax.swing.Icon
 
 class DgsSymbolContributor : ChooseByNameContributor {
@@ -44,7 +45,10 @@ class DgsSymbolContributor : ChooseByNameContributor {
         val dgsService = project.getService(DgsService::class.java)
         return dgsService.dgsComponentIndex.getAllComponents()
             .filter { it.name == name }
-            .map { DgsComponentNavigationItem(it.name, project, it.psiAnnotation, it.psiAnnotation.parentOfType<PsiClass>()?.qualifiedName, it.type.description) }
+            .map {
+                val qualifier = it.psiAnnotation.toUElement()?.getParentOfType<UClass>()?.qualifiedName
+                DgsComponentNavigationItem(it.name, project, it.psiAnnotation, qualifier, it.type.description)
+            }
             .toTypedArray()
     }
 }

--- a/src/main/kotlin/com/netflix/dgs/plugin/services/DgsDataProcessor.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/services/DgsDataProcessor.kt
@@ -28,6 +28,7 @@ import org.jetbrains.uast.UAnnotation
 import org.jetbrains.uast.UClass
 import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.getParentOfType
+import org.jetbrains.uast.toUElement
 
 class DgsComponentProcessor(
     private val graphQLSchemaRegistry: GraphQLSchemaRegistry,
@@ -160,15 +161,17 @@ class DgsComponentProcessor(
                     }
                 }
 
-                annotations.forEach { createDataFetchersForAnnotation(uMethod, methodPsi, it, uAnnotation.sourcePsi?.containingFile!!) }
+                annotations.forEach { psiAnnotation ->
+                    val childUAnnotation = psiAnnotation.toUElement() as? UAnnotation ?: return@forEach
+                    createDataFetchersForAnnotation(uMethod, methodPsi, childUAnnotation, psiAnnotation)
+                }
             }
         } else {
-            // Individual @DgsData annotation - process directly to preserve PSI element for navigation
-            // This handles both single @DgsData and implicit @Repeatable cases
-            val annotationPsi = uAnnotation.sourcePsi as? PsiAnnotation
-            if (annotationPsi != null) {
-                createDataFetchersForAnnotation(uMethod, methodPsi, annotationPsi, uAnnotation.sourcePsi?.containingFile!!)
-            }
+            // Individual annotation — works for both Java (sourcePsi is PsiAnnotation) and
+            // Kotlin (sourcePsi is KtAnnotationEntry). Store sourcePsi directly so that the
+            // psiAnnotation identity comparison in marker providers works for both languages.
+            val annotationSourcePsi = uAnnotation.sourcePsi ?: return
+            createDataFetchersForAnnotation(uMethod, methodPsi, uAnnotation, annotationSourcePsi)
         }
     }
 
@@ -179,11 +182,12 @@ class DgsComponentProcessor(
     private fun createDataFetchersForAnnotation(
         uMethod: UMethod,
         methodPsi: PsiElement,
-        annotation: PsiAnnotation,
-        containingFile: com.intellij.psi.PsiFile
+        uAnnotation: UAnnotation,
+        annotationSourcePsi: PsiElement
     ) {
-        val parentType = DgsDataFetcher.getParentType(annotation)
-        val field = DgsDataFetcher.getFieldFromAnnotation(annotation) ?: uMethod.name
+        val parentType = DgsDataFetcher.getParentType(uAnnotation)
+        val field = DgsDataFetcher.getFieldFromAnnotation(uAnnotation) ?: uMethod.name
+        val containingFile = annotationSourcePsi.containingFile
 
         // Because we use the stubs index, we might process a @DgsQuery annotation as @DgsData as well, which won't have parentType.
         if (parentType != null) {
@@ -191,7 +195,7 @@ class DgsComponentProcessor(
                 parentType,
                 field,
                 methodPsi,
-                annotation,
+                annotationSourcePsi,
                 containingFile,
                 graphQLSchemaRegistry.psiForSchemaType(uMethod, parentType, field)?.orNull()
             )
@@ -205,7 +209,7 @@ class DgsComponentProcessor(
                     implementingType,
                     field,
                     methodPsi,
-                    annotation,
+                    annotationSourcePsi,
                     containingFile,
                     graphQLSchemaRegistry.psiForSchemaType(uMethod, implementingType, field)?.orNull()
                 )


### PR DESCRIPTION
Hey guys. It's now been a while since data fetchers navigation stopped working for my colleagues and me, so I decided to try to find and fix the issue using AI. I'm not specializing in Java/Kotlin development.

I tested it for the following IDEA versions:

- 2024.3.1 by running `./gradlew runIde`
- 2025.3.4 by upgrading versions in `gradle.properties`, upgrading `org.jetbrains.kotlin.jvm` to `2.3.20` and running `./gradlew runIde`
- 2026.1 by upgrading versions in `gradle.properties`, upgrading `org.jetbrains.kotlin.jvm` to `2.3.20` and running `./gradlew runIde`
- 2026.1 in my locally installed IDEA by building the plugin and installing it from the result .zip file

Below is the AI summary of the bug that I asked it to write:

## Issue

Gutter icons in Kotlin DGS projects appear as gray / unresolved ("no fetcher found"
variant). Clicking them does nothing — navigation to the GraphQL schema field is
completely broken. Java DGS projects are unaffected throughout.

Related issues: #83, #88, #102.

---

## Root cause

In `DgsDataProcessor.kt`, the `processDataFetcher` method had:

```kotlin
val annotationPsi = uAnnotation.sourcePsi as? PsiAnnotation
if (annotationPsi != null) {
    createDataFetchersForAnnotation(uMethod, methodPsi, annotationPsi, ...)
}
```

`PsiAnnotation` is a Java PSI interface. Java source annotations implement it
directly. Kotlin source annotations use `KtAnnotationEntry`, which does **not**
implement `PsiAnnotation`. The cast therefore always returned `null` for Kotlin,
`createDataFetchersForAnnotation` was never called, and no Kotlin data fetcher
was ever added to the component index.

The bug was introduced in commit `2a4abb6` ("Properly handle implicit DgsData.List
linkage", 2025-12-18), which refactored `processDataFetcher` to separate the
`@DgsData.List` container case but accidentally added the cast to the `else` branch.
The original Kotlin compatibility commit from 2021 had used `uAnnotation.sourcePsi`
directly without casting.

It went undetected because all existing test data files are Java; the Kotlin code
path was never exercised by tests.

---

## Fix

**`DgsDataProcessor.kt`** — in the `else` branch, replace the `as? PsiAnnotation`
cast with `uAnnotation.sourcePsi ?: return` and pass the `UAnnotation` directly to
`createDataFetchersForAnnotation`. The method signature changes from
`annotation: PsiAnnotation` to `uAnnotation: UAnnotation` + `annotationSourcePsi: PsiElement`,
so annotation attributes are read via UAST (works for both languages) while the
source PSI element is stored as-is for navigation.

In the `@DgsData.List` branch, each extracted child `PsiAnnotation` is now converted
to `UAnnotation` via `toUElement()` before being passed to the same method, keeping
a single code path for the indexing logic.

**`DgsDataFetcher.kt`** — add `UAnnotation` overloads for `getParentType` and
`getFieldFromAnnotation` as the primary implementations; make the existing
`PsiAnnotation` overloads delegate through them. This also removes an unsafe bare
`as UAnnotation` cast that was already present in the original code.

---

## Tests

No test changes. The existing `DgsDataMultipleAnnotationsTest` covers both the
implicit `@Repeatable` and explicit `@DgsData.List` cases with Java test data and
was already asserting correct fetcher counts, `parentType`/`field` values, schema
linkage, shared method references, and distinct annotation PSI elements per entry.
All tests pass.

---

## Verified working

Manually tested via `./gradlew runIde` on:

| IDE version | Build |
|---|---|
| IntelliJ IDEA 2025.3.4 | IU-253.32098.37 |
| IntelliJ IDEA 2026.1 | IU-261.22158.277 |

Gutter icons appear next to `@DgsQuery` / `@DgsMutation` / `@DgsData` methods in
Kotlin DGS projects and navigate correctly to the GraphQL schema field.