### PR TITLE
Hide unresolved marker on auto-resolved schema sub-fields

### DIFF
--- a/src/main/kotlin/com/netflix/dgs/plugin/navigation/UnresolvedSchemaMarkerProvider.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/navigation/UnresolvedSchemaMarkerProvider.kt
@@ -27,6 +27,9 @@ import com.netflix.dgs.plugin.DgsConstants
 import com.netflix.dgs.plugin.services.DgsService
 import javax.swing.Icon
 
+private val ROOT_OPERATION_TYPES = setOf("Query", "Mutation", "Subscription")
+private val DIRECTIVES_REQUIRING_RESOLUTION = setOf("requires", "external")
+
 class UnresolvedSchemaMarkerProvider : RelatedItemLineMarkerProvider() {
 
     override fun getName(): String = "DGS Unresolved Schema Elements"
@@ -53,13 +56,29 @@ class UnresolvedSchemaMarkerProvider : RelatedItemLineMarkerProvider() {
 
         val iconBuilder = when (element) {
             is GraphQLFieldDefinition -> {
-                val fetcher = dgsService.dgsComponentIndex.dataFetchers.find { it.schemaPsi == element }
-                if (fetcher == null) {
-                    NavigationGutterIconBuilder.create(DgsConstants.dgsUnresolvedIcon)
-                        .setTargets(emptyList())
-                        .setTooltipText("No DGS data fetcher found")
-                        .createLineMarkerInfo(psiLeaf)
-                } else null
+                // Only flag fields that genuinely need a data fetcher:
+                //   - Fields on Query/Mutation/Subscription (root operations always need one)
+                //   - Fields with arguments (DGS can't auto-process arguments)
+                //   - Fields with federation directives that require resolution logic
+                // Sub-fields on regular types without arguments are auto-resolved by DGS
+                // from the parent object's properties, so they don't need a fetcher.
+                val parentTypeName = (element.parent?.parent as? GraphQLNamedElement)?.name
+                val isRootOperationField = parentTypeName in ROOT_OPERATION_TYPES
+                val hasArguments = element.argumentsDefinition?.inputValueDefinitionList.orEmpty().isNotEmpty()
+                val requiresResolutionLogic = element.directives.any { directive ->
+                    (directive.nameIdentifier as? GraphQLIdentifierImpl)?.name in DIRECTIVES_REQUIRING_RESOLUTION
+                }
+                if (!isRootOperationField && !hasArguments && !requiresResolutionLogic) {
+                    null
+                } else {
+                    val fetcher = dgsService.dgsComponentIndex.dataFetchers.find { it.schemaPsi == element }
+                    if (fetcher == null) {
+                        NavigationGutterIconBuilder.create(DgsConstants.dgsUnresolvedIcon)
+                            .setTargets(emptyList())
+                            .setTooltipText("No DGS data fetcher found")
+                            .createLineMarkerInfo(psiLeaf)
+                    } else null
+                }
             }
             is GraphQLObjectTypeDefinition, is GraphQLObjectTypeExtensionDefinition -> {
                 val entityFetcher = dgsService.dgsComponentIndex.entityFetchers.find { it.schemaPsi == element }

--- a/src/main/kotlin/com/netflix/dgs/plugin/navigation/UnresolvedSchemaMarkerProvider.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/navigation/UnresolvedSchemaMarkerProvider.kt
@@ -58,17 +58,16 @@ class UnresolvedSchemaMarkerProvider : RelatedItemLineMarkerProvider() {
             is GraphQLFieldDefinition -> {
                 // Only flag fields that genuinely need a data fetcher:
                 //   - Fields on Query/Mutation/Subscription (root operations always need one)
-                //   - Fields with arguments (DGS can't auto-process arguments)
-                //   - Fields with federation directives that require resolution logic
-                // Sub-fields on regular types without arguments are auto-resolved by DGS
-                // from the parent object's properties, so they don't need a fetcher.
+                //   - Fields with @requires/@external (federation resolution can't auto-resolve)
+                // Sub-fields on regular types are auto-resolved by DGS from the parent object's
+                // properties or matching methods (including methods with arguments), so they
+                // don't need an explicit fetcher.
                 val parentTypeName = (element.parent?.parent as? GraphQLNamedElement)?.name
                 val isRootOperationField = parentTypeName in ROOT_OPERATION_TYPES
-                val hasArguments = element.argumentsDefinition?.inputValueDefinitionList.orEmpty().isNotEmpty()
                 val requiresResolutionLogic = element.directives.any { directive ->
                     (directive.nameIdentifier as? GraphQLIdentifierImpl)?.name in DIRECTIVES_REQUIRING_RESOLUTION
                 }
-                if (!isRootOperationField && !hasArguments && !requiresResolutionLogic) {
+                if (!isRootOperationField && !requiresResolutionLogic) {
                     null
                 } else {
                     val fetcher = dgsService.dgsComponentIndex.dataFetchers.find { it.schemaPsi == element }


### PR DESCRIPTION
## Summary

`UnresolvedSchemaMarkerProvider` flagged every field without a `@DgsData` fetcher, including scalar sub-fields like `id` or `url` that DGS auto-resolves from POJO properties. In large schemas this produced hundreds of false-positive grey icons.

   > New approach

   The grey marker now fires only on fields that actually need a fetcher:

   - Root operation fields (`Query` / `Mutation` / `Subscription`)
   - Fields with `@requires` or `@external` federation directives

## Test plan

- [x] Verified on a minimal federation schema: scalar sub-fields (`id`, `url` on a non-entity `Thumbnail` type) lose the grey icon; root-op fields, fields with args, and `@external` fields still get checked; resolved navigation icons preserved.

| Before  | After|
| ------------- | ------------- |
| <img width="413" height="465" alt="image" src="https://github.com/user-attachments/assets/04a6fd9c-467a-46a8-a9aa-780b0ef63ae7" /> | <img width="450" height="464" alt="image" src="https://github.com/user-attachments/assets/128eeea2-7141-4e89-a285-5ccf70a7938c" />  |