### PR TITLE
Add cmd+click navigation on @DgsData annotation strings

### DIFF
--- a/src/main/java/com/netflix/dgs/plugin/services/internal/GraphQLSchemaRegistry.java
+++ b/src/main/java/com/netflix/dgs/plugin/services/internal/GraphQLSchemaRegistry.java
@@ -73,6 +73,19 @@ public class GraphQLSchemaRegistry {
         return Optional.empty();
     }
 
+    public Optional<PsiElement> psiForType(@NotNull PsiElement psiElement, @NotNull String typeName) {
+        TypeDefinitionRegistry registry = getRegistry(psiElement);
+        Optional<ObjectTypeDefinition> objectType = getTypeDefinition(registry, typeName);
+        if (objectType.isPresent()) {
+            return Optional.ofNullable(GraphQLTypeDefinitionUtil.findElement(objectType.get().getSourceLocation(), psiElement.getProject()));
+        }
+        Optional<InterfaceTypeDefinition> interfaceType = getInterfaceTypeDefinition(registry, typeName);
+        if (interfaceType.isPresent()) {
+            return Optional.ofNullable(GraphQLTypeDefinitionUtil.findElement(interfaceType.get().getSourceLocation(), psiElement.getProject()));
+        }
+        return Optional.empty();
+    }
+
     public Optional<PsiElement> psiForDirective(@NotNull PsiElement psiElement, @NotNull String name) {
         TypeDefinitionRegistry registry = getRegistry(psiElement);
         Optional<DirectiveDefinition> directiveDefinition = registry.getDirectiveDefinition(name);

--- a/src/main/kotlin/com/netflix/dgs/plugin/navigation/DgsAnnotationGotoDeclarationHandler.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/navigation/DgsAnnotationGotoDeclarationHandler.kt
@@ -57,6 +57,7 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
     private data class AnnotationContext(val attrName: String, val value: String, val annotation: PsiElement)
 
     private fun extractContext(element: PsiElement): AnnotationContext? {
+        // sourceElement is the cursor's leaf PSI token; walk up to the enclosing string literal.
         val stringElement: PsiElement =
             PsiTreeUtil.getParentOfType(element, KtStringTemplateExpression::class.java, false)
                 ?: PsiTreeUtil.getParentOfType(element, PsiLiteralExpression::class.java, false)
@@ -81,6 +82,7 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
     private fun stringValue(element: PsiElement): String? = when (element) {
         is PsiLiteralExpression -> element.value as? String
         is KtStringTemplateExpression ->
+            // Skip interpolated strings ("${foo}") — dynamic values can't be matched against the static index.
             if (element.hasInterpolation()) null
             else element.entries.firstOrNull()?.text
         else -> null
@@ -99,6 +101,7 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
         val fetcher = dgsService.dgsComponentIndex.dataFetchers
             .firstOrNull { it.parentType == typeName && it.schemaPsi != null }
         val fieldPsi = fetcher?.schemaPsi ?: return null
+        // Walk field → GraphQLFieldsDefinition → GraphQLObjectTypeDefinition.
         val typePsi = fieldPsi.parent?.parent ?: fieldPsi.parent ?: return null
         return arrayOf(nameIdentifier(typePsi))
     }
@@ -110,6 +113,7 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
         return arrayOf(nameIdentifier(schemaPsi))
     }
 
+    // Returning the inner identifier (rather than the whole def) gives IntelliJ a clean hover label.
     private fun nameIdentifier(element: PsiElement): PsiElement =
         PsiTreeUtil.findChildOfType(element, GraphQLIdentifierImpl::class.java) ?: element
 

--- a/src/main/kotlin/com/netflix/dgs/plugin/navigation/DgsAnnotationGotoDeclarationHandler.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/navigation/DgsAnnotationGotoDeclarationHandler.kt
@@ -17,6 +17,7 @@
 package com.netflix.dgs.plugin.navigation
 
 import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler
+import com.intellij.lang.jsgraphql.psi.impl.GraphQLIdentifierImpl
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiElement
@@ -99,15 +100,18 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
             .firstOrNull { it.parentType == typeName && it.schemaPsi != null }
         val fieldPsi = fetcher?.schemaPsi ?: return null
         val typePsi = fieldPsi.parent?.parent ?: fieldPsi.parent ?: return null
-        return arrayOf(typePsi)
+        return arrayOf(nameIdentifier(typePsi))
     }
 
     private fun resolveField(parentType: String, fieldName: String, dgsService: DgsService): Array<PsiElement>? {
         val fetcher = dgsService.dgsComponentIndex.dataFetchers
             .firstOrNull { it.parentType == parentType && it.field == fieldName && it.schemaPsi != null }
         val schemaPsi = fetcher?.schemaPsi ?: return null
-        return arrayOf(schemaPsi)
+        return arrayOf(nameIdentifier(schemaPsi))
     }
+
+    private fun nameIdentifier(element: PsiElement): PsiElement =
+        PsiTreeUtil.findChildOfType(element, GraphQLIdentifierImpl::class.java) ?: element
 
     private fun resolveParentType(annotation: PsiElement, shortName: String): String? =
         when (shortName) {

--- a/src/main/kotlin/com/netflix/dgs/plugin/navigation/DgsAnnotationGotoDeclarationHandler.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/navigation/DgsAnnotationGotoDeclarationHandler.kt
@@ -21,13 +21,16 @@ import com.intellij.lang.jsgraphql.psi.impl.GraphQLIdentifierImpl
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.PsiNameValuePair
 import com.intellij.psi.util.PsiTreeUtil
 import com.netflix.dgs.plugin.services.DgsService
+import com.netflix.dgs.plugin.services.internal.GraphQLSchemaRegistry
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
-import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.uast.UAnnotation
+import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.evaluateString
+import org.jetbrains.uast.toUElement
 
 class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
 
@@ -38,18 +41,21 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
     ): Array<PsiElement>? {
         sourceElement ?: return null
 
-        val dgsService = sourceElement.project.getService(DgsService::class.java)
-        if (!dgsService.isDgsProject(sourceElement.project)) return null
+        val project = sourceElement.project
+        val dgsService = project.getService(DgsService::class.java)
+        if (!dgsService.isDgsProject(project)) return null
 
         val context = extractContext(sourceElement) ?: return null
         if (!isDgsDataAnnotation(context.annotation)) return null
 
+        val schemaRegistry = project.getService(GraphQLSchemaRegistry::class.java)
+
         return when (context.attrName) {
-            "parentType" -> resolveType(context.value, dgsService)
-            "name" -> if (shortName(context.annotation) == "DgsEntityFetcher") resolveType(context.value, dgsService) else null
+            "parentType" -> resolveType(context.value, sourceElement, schemaRegistry)
+            "name" -> if (shortName(context.annotation) == "DgsEntityFetcher") resolveType(context.value, sourceElement, schemaRegistry) else null
             "field" -> {
                 val parentType = resolveParentType(context.annotation, shortName(context.annotation)) ?: return null
-                resolveField(parentType, context.value, dgsService)
+                resolveField(parentType, context.value, sourceElement, schemaRegistry)
             }
             else -> null
         }
@@ -58,35 +64,28 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
     private data class AnnotationContext(val attrName: String, val value: String, val annotation: PsiElement)
 
     private fun extractContext(element: PsiElement): AnnotationContext? {
-        // sourceElement is the cursor's leaf PSI token; walk up to the enclosing string literal.
-        val stringElement: PsiElement =
-            PsiTreeUtil.getParentOfType(element, KtStringTemplateExpression::class.java, false)
-                ?: PsiTreeUtil.getParentOfType(element, PsiLiteralExpression::class.java, false)
-                ?: return null
-
-        val value = stringValue(stringElement) ?: return null
-
-        if (stringElement is PsiLiteralExpression) {
-            val pair = stringElement.parent as? PsiNameValuePair ?: return null
-            val annotation = pair.parent?.parent as? PsiAnnotation ?: return null
-            return AnnotationContext(pair.name ?: "value", value, annotation)
+        // Java: cursor inside a @Foo(attr = ...) parameter
+        val javaPair = PsiTreeUtil.getParentOfType(element, PsiNameValuePair::class.java, false)
+        if (javaPair != null) {
+            val valueExpr = javaPair.value ?: return null
+            // Ignore clicks on the attribute name; only resolve when cursor is in the value.
+            if (!PsiTreeUtil.isAncestor(valueExpr, element, false)) return null
+            val annotation = javaPair.parent?.parent as? PsiAnnotation ?: return null
+            // UAST evaluates literals and constant references (Constants.MOVIE_TYPE) uniformly.
+            val value = (valueExpr.toUElement() as? UExpression)?.evaluateString() ?: return null
+            return AnnotationContext(javaPair.name ?: "value", value, annotation)
         }
-        if (stringElement is KtStringTemplateExpression) {
-            val arg = stringElement.parent as? KtValueArgument ?: return null
-            val annotation = arg.parent?.parent as? KtAnnotationEntry ?: return null
-            val argName = arg.getArgumentName()?.asName?.identifier ?: "value"
+        // Kotlin: cursor inside a @Foo(attr = ...) argument
+        val ktArg = PsiTreeUtil.getParentOfType(element, KtValueArgument::class.java, false)
+        if (ktArg != null) {
+            val valueExpr = ktArg.getArgumentExpression() ?: return null
+            if (!PsiTreeUtil.isAncestor(valueExpr, element, false)) return null
+            val annotation = ktArg.parent?.parent as? KtAnnotationEntry ?: return null
+            val value = (valueExpr.toUElement() as? UExpression)?.evaluateString() ?: return null
+            val argName = ktArg.getArgumentName()?.asName?.identifier ?: "value"
             return AnnotationContext(argName, value, annotation)
         }
         return null
-    }
-
-    private fun stringValue(element: PsiElement): String? = when (element) {
-        is PsiLiteralExpression -> element.value as? String
-        is KtStringTemplateExpression ->
-            // Skip interpolated strings ("${foo}") — dynamic values can't be matched against the static index.
-            if (element.hasInterpolation()) null
-            else element.entries.firstOrNull()?.text
-        else -> null
     }
 
     private fun shortName(annotation: PsiElement): String = when (annotation) {
@@ -98,20 +97,23 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
     private fun isDgsDataAnnotation(annotation: PsiElement): Boolean =
         shortName(annotation) in DGS_SHORT_NAMES
 
-    private fun resolveType(typeName: String, dgsService: DgsService): Array<PsiElement>? {
-        val fetcher = dgsService.dgsComponentIndex.dataFetchers
-            .firstOrNull { it.parentType == typeName && it.schemaPsi != null }
-        val fieldPsi = fetcher?.schemaPsi ?: return null
-        // Walk field → GraphQLFieldsDefinition → GraphQLObjectTypeDefinition.
-        val typePsi = fieldPsi.parent?.parent ?: fieldPsi.parent ?: return null
+    private fun resolveType(
+        typeName: String,
+        sourceElement: PsiElement,
+        schemaRegistry: GraphQLSchemaRegistry
+    ): Array<PsiElement>? {
+        val typePsi = schemaRegistry.psiForType(sourceElement, typeName).orElse(null) ?: return null
         return arrayOf(nameIdentifier(typePsi))
     }
 
-    private fun resolveField(parentType: String, fieldName: String, dgsService: DgsService): Array<PsiElement>? {
-        val fetcher = dgsService.dgsComponentIndex.dataFetchers
-            .firstOrNull { it.parentType == parentType && it.field == fieldName && it.schemaPsi != null }
-        val schemaPsi = fetcher?.schemaPsi ?: return null
-        return arrayOf(nameIdentifier(schemaPsi))
+    private fun resolveField(
+        parentType: String,
+        fieldName: String,
+        sourceElement: PsiElement,
+        schemaRegistry: GraphQLSchemaRegistry
+    ): Array<PsiElement>? {
+        val fieldPsi = schemaRegistry.psiForSchemaType(sourceElement, parentType, fieldName)?.orElse(null) ?: return null
+        return arrayOf(nameIdentifier(fieldPsi))
     }
 
     // Returning the inner identifier (rather than the whole def) gives IntelliJ a clean hover label.
@@ -126,14 +128,9 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
             else -> siblingValue(annotation, "parentType")
         }
 
-    private fun siblingValue(annotation: PsiElement, attrName: String): String? = when (annotation) {
-        is PsiAnnotation -> (annotation.findAttributeValue(attrName) as? PsiLiteralExpression)?.value as? String
-        is KtAnnotationEntry -> annotation.valueArguments
-            .firstOrNull { it.getArgumentName()?.asName?.identifier == attrName }
-            ?.getArgumentExpression()
-            ?.let { it as? KtStringTemplateExpression }
-            ?.entries?.firstOrNull()?.text
-        else -> null
+    private fun siblingValue(annotation: PsiElement, attrName: String): String? {
+        val uAnnotation = annotation.toUElement() as? UAnnotation ?: return null
+        return uAnnotation.findAttributeValue(attrName)?.evaluateString()
     }
 
     companion object {

--- a/src/main/kotlin/com/netflix/dgs/plugin/navigation/DgsAnnotationGotoDeclarationHandler.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/navigation/DgsAnnotationGotoDeclarationHandler.kt
@@ -45,7 +45,8 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
         if (!isDgsDataAnnotation(context.annotation)) return null
 
         return when (context.attrName) {
-            "parentType", "typename" -> resolveType(context.value, dgsService)
+            "parentType" -> resolveType(context.value, dgsService)
+            "name" -> if (shortName(context.annotation) == "DgsEntityFetcher") resolveType(context.value, dgsService) else null
             "field" -> {
                 val parentType = resolveParentType(context.annotation, shortName(context.annotation)) ?: return null
                 resolveField(parentType, context.value, dgsService)

--- a/src/main/kotlin/com/netflix/dgs/plugin/navigation/DgsAnnotationGotoDeclarationHandler.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/navigation/DgsAnnotationGotoDeclarationHandler.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.dgs.plugin.navigation
+
+import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiLiteralExpression
+import com.intellij.psi.PsiNameValuePair
+import com.intellij.psi.util.PsiTreeUtil
+import com.netflix.dgs.plugin.services.DgsService
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.KtValueArgument
+
+class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
+
+    override fun getGotoDeclarationTargets(
+        sourceElement: PsiElement?,
+        offset: Int,
+        editor: Editor
+    ): Array<PsiElement>? {
+        sourceElement ?: return null
+
+        val dgsService = sourceElement.project.getService(DgsService::class.java)
+        if (!dgsService.isDgsProject(sourceElement.project)) return null
+
+        val context = extractContext(sourceElement) ?: return null
+        if (!isDgsDataAnnotation(context.annotation)) return null
+
+        return when (context.attrName) {
+            "parentType", "typename" -> resolveType(context.value, dgsService)
+            "field" -> {
+                val parentType = resolveParentType(context.annotation, shortName(context.annotation)) ?: return null
+                resolveField(parentType, context.value, dgsService)
+            }
+            else -> null
+        }
+    }
+
+    private data class AnnotationContext(val attrName: String, val value: String, val annotation: PsiElement)
+
+    private fun extractContext(element: PsiElement): AnnotationContext? {
+        val stringElement: PsiElement =
+            PsiTreeUtil.getParentOfType(element, KtStringTemplateExpression::class.java, false)
+                ?: PsiTreeUtil.getParentOfType(element, PsiLiteralExpression::class.java, false)
+                ?: return null
+
+        val value = stringValue(stringElement) ?: return null
+
+        if (stringElement is PsiLiteralExpression) {
+            val pair = stringElement.parent as? PsiNameValuePair ?: return null
+            val annotation = pair.parent?.parent as? PsiAnnotation ?: return null
+            return AnnotationContext(pair.name ?: "value", value, annotation)
+        }
+        if (stringElement is KtStringTemplateExpression) {
+            val arg = stringElement.parent as? KtValueArgument ?: return null
+            val annotation = arg.parent?.parent as? KtAnnotationEntry ?: return null
+            val argName = arg.getArgumentName()?.asName?.identifier ?: "value"
+            return AnnotationContext(argName, value, annotation)
+        }
+        return null
+    }
+
+    private fun stringValue(element: PsiElement): String? = when (element) {
+        is PsiLiteralExpression -> element.value as? String
+        is KtStringTemplateExpression ->
+            if (element.hasInterpolation()) null
+            else element.entries.firstOrNull()?.text
+        else -> null
+    }
+
+    private fun shortName(annotation: PsiElement): String = when (annotation) {
+        is PsiAnnotation -> annotation.qualifiedName?.substringAfterLast('.') ?: ""
+        is KtAnnotationEntry -> annotation.shortName?.identifier ?: ""
+        else -> ""
+    }
+
+    private fun isDgsDataAnnotation(annotation: PsiElement): Boolean =
+        shortName(annotation) in DGS_SHORT_NAMES
+
+    private fun resolveType(typeName: String, dgsService: DgsService): Array<PsiElement>? {
+        val fetcher = dgsService.dgsComponentIndex.dataFetchers
+            .firstOrNull { it.parentType == typeName && it.schemaPsi != null }
+        val fieldPsi = fetcher?.schemaPsi ?: return null
+        val typePsi = fieldPsi.parent?.parent ?: fieldPsi.parent ?: return null
+        return arrayOf(typePsi)
+    }
+
+    private fun resolveField(parentType: String, fieldName: String, dgsService: DgsService): Array<PsiElement>? {
+        val fetcher = dgsService.dgsComponentIndex.dataFetchers
+            .firstOrNull { it.parentType == parentType && it.field == fieldName && it.schemaPsi != null }
+        val schemaPsi = fetcher?.schemaPsi ?: return null
+        return arrayOf(schemaPsi)
+    }
+
+    private fun resolveParentType(annotation: PsiElement, shortName: String): String? =
+        when (shortName) {
+            "DgsQuery" -> "Query"
+            "DgsMutation" -> "Mutation"
+            "DgsSubscription" -> "Subscription"
+            else -> siblingValue(annotation, "parentType")
+        }
+
+    private fun siblingValue(annotation: PsiElement, attrName: String): String? = when (annotation) {
+        is PsiAnnotation -> (annotation.findAttributeValue(attrName) as? PsiLiteralExpression)?.value as? String
+        is KtAnnotationEntry -> annotation.valueArguments
+            .firstOrNull { it.getArgumentName()?.asName?.identifier == attrName }
+            ?.getArgumentExpression()
+            ?.let { it as? KtStringTemplateExpression }
+            ?.entries?.firstOrNull()?.text
+        else -> null
+    }
+
+    companion object {
+        private val DGS_SHORT_NAMES = setOf(
+            "DgsData", "DgsQuery", "DgsMutation", "DgsSubscription", "DgsEntityFetcher"
+        )
+    }
+}

--- a/src/main/kotlin/com/netflix/dgs/plugin/navigation/DgsAnnotationGotoDeclarationHandler.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/navigation/DgsAnnotationGotoDeclarationHandler.kt
@@ -19,13 +19,13 @@ package com.netflix.dgs.plugin.navigation
 import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler
 import com.intellij.lang.jsgraphql.psi.impl.GraphQLIdentifierImpl
 import com.intellij.openapi.editor.Editor
-import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNameValuePair
 import com.intellij.psi.util.PsiTreeUtil
+import com.netflix.dgs.plugin.DgsDataFetcher
+import com.netflix.dgs.plugin.DgsEntityFetcher
 import com.netflix.dgs.plugin.services.DgsService
 import com.netflix.dgs.plugin.services.internal.GraphQLSchemaRegistry
-import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.uast.UAnnotation
 import org.jetbrains.uast.UExpression
@@ -46,22 +46,25 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
         if (!dgsService.isDgsProject(project)) return null
 
         val context = extractContext(sourceElement) ?: return null
-        if (!isDgsDataAnnotation(context.annotation)) return null
+        val uAnnotation = context.annotationPsi.toUElement() as? UAnnotation ?: return null
+        if (!isDgsAnnotation(uAnnotation)) return null
 
         val schemaRegistry = project.getService(GraphQLSchemaRegistry::class.java)
 
         return when (context.attrName) {
             "parentType" -> resolveType(context.value, sourceElement, schemaRegistry)
-            "name" -> if (shortName(context.annotation) == "DgsEntityFetcher") resolveType(context.value, sourceElement, schemaRegistry) else null
+            "name" -> if (uAnnotation.qualifiedName == DGS_ENTITY_FETCHER_FQN) {
+                resolveType(context.value, sourceElement, schemaRegistry)
+            } else null
             "field" -> {
-                val parentType = resolveParentType(context.annotation, shortName(context.annotation)) ?: return null
+                val parentType = resolveParentType(uAnnotation) ?: return null
                 resolveField(parentType, context.value, sourceElement, schemaRegistry)
             }
             else -> null
         }
     }
 
-    private data class AnnotationContext(val attrName: String, val value: String, val annotation: PsiElement)
+    private data class AnnotationContext(val attrName: String, val value: String, val annotationPsi: PsiElement)
 
     private fun extractContext(element: PsiElement): AnnotationContext? {
         // Java: cursor inside a @Foo(attr = ...) parameter
@@ -70,7 +73,7 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
             val valueExpr = javaPair.value ?: return null
             // Ignore clicks on the attribute name; only resolve when cursor is in the value.
             if (!PsiTreeUtil.isAncestor(valueExpr, element, false)) return null
-            val annotation = javaPair.parent?.parent as? PsiAnnotation ?: return null
+            val annotation = javaPair.parent?.parent ?: return null
             // UAST evaluates literals and constant references (Constants.MOVIE_TYPE) uniformly.
             val value = (valueExpr.toUElement() as? UExpression)?.evaluateString() ?: return null
             return AnnotationContext(javaPair.name ?: "value", value, annotation)
@@ -80,7 +83,7 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
         if (ktArg != null) {
             val valueExpr = ktArg.getArgumentExpression() ?: return null
             if (!PsiTreeUtil.isAncestor(valueExpr, element, false)) return null
-            val annotation = ktArg.parent?.parent as? KtAnnotationEntry ?: return null
+            val annotation = ktArg.parent?.parent ?: return null
             val value = (valueExpr.toUElement() as? UExpression)?.evaluateString() ?: return null
             val argName = ktArg.getArgumentName()?.asName?.identifier ?: "value"
             return AnnotationContext(argName, value, annotation)
@@ -88,14 +91,9 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
         return null
     }
 
-    private fun shortName(annotation: PsiElement): String = when (annotation) {
-        is PsiAnnotation -> annotation.qualifiedName?.substringAfterLast('.') ?: ""
-        is KtAnnotationEntry -> annotation.shortName?.identifier ?: ""
-        else -> ""
-    }
-
-    private fun isDgsDataAnnotation(annotation: PsiElement): Boolean =
-        shortName(annotation) in DGS_SHORT_NAMES
+    private fun isDgsAnnotation(annotation: UAnnotation): Boolean =
+        DgsDataFetcher.isDataFetcherAnnotation(annotation) ||
+            DgsEntityFetcher.isEntityFetcherAnnotation(annotation)
 
     private fun resolveType(
         typeName: String,
@@ -120,22 +118,15 @@ class DgsAnnotationGotoDeclarationHandler : GotoDeclarationHandler {
     private fun nameIdentifier(element: PsiElement): PsiElement =
         PsiTreeUtil.findChildOfType(element, GraphQLIdentifierImpl::class.java) ?: element
 
-    private fun resolveParentType(annotation: PsiElement, shortName: String): String? =
-        when (shortName) {
-            "DgsQuery" -> "Query"
-            "DgsMutation" -> "Mutation"
-            "DgsSubscription" -> "Subscription"
-            else -> siblingValue(annotation, "parentType")
+    private fun resolveParentType(annotation: UAnnotation): String? =
+        when (annotation.qualifiedName) {
+            "com.netflix.graphql.dgs.DgsQuery" -> "Query"
+            "com.netflix.graphql.dgs.DgsMutation" -> "Mutation"
+            "com.netflix.graphql.dgs.DgsSubscription" -> "Subscription"
+            else -> annotation.findAttributeValue("parentType")?.evaluateString()
         }
 
-    private fun siblingValue(annotation: PsiElement, attrName: String): String? {
-        val uAnnotation = annotation.toUElement() as? UAnnotation ?: return null
-        return uAnnotation.findAttributeValue(attrName)?.evaluateString()
-    }
-
     companion object {
-        private val DGS_SHORT_NAMES = setOf(
-            "DgsData", "DgsQuery", "DgsMutation", "DgsSubscription", "DgsEntityFetcher"
-        )
+        private const val DGS_ENTITY_FETCHER_FQN = "com.netflix.graphql.dgs.DgsEntityFetcher"
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -54,6 +54,8 @@
         <codeInsight.lineMarkerProvider language="GraphQL" implementationClass="com.netflix.dgs.plugin.navigation.SchemaToDataFetcherMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="GraphQL" implementationClass="com.netflix.dgs.plugin.navigation.UnresolvedSchemaMarkerProvider"/>
 
+        <gotoDeclarationHandler implementation="com.netflix.dgs.plugin.navigation.DgsAnnotationGotoDeclarationHandler"/>
+
         <implicitUsageProvider implementation="com.netflix.dgs.plugin.provider.DgsImplicitUsageProvider"/>
 
         <treeStructureProvider implementation="com.netflix.dgs.plugin.provider.DgsProjectStructureProvider"/>


### PR DESCRIPTION
## Summary

⌘+Click on the string values inside `@DgsData`, `@DgsQuery`, `@DgsMutation`, `@DgsSubscription`, and `@DgsEntityFetcher` now navigates to the corresponding schema element:

- ⌘+Click on `parentType` value → jumps to `type Foo { ... }` in the schema
- ⌘+Click on `field` value → jumps to the field declaration

Works in both Java and Kotlin sources.

<img width="1160" height="277" alt="image" src="https://github.com/user-attachments/assets/df37633d-1486-48b6-9bc7-0a001fca7c60" />


## Why

The existing gutter icons already navigate at the method level. Developers naturally try ⌘+Click on the annotation string itself and get "Cannot find declaration to go to." This handler fills that gap.

## Test Plan
  - [x] In a `@DgsData(parentType = "Movie", field = "thumbnail")` method, ⌘+Click on `"Movie"` → jumps to `type Movie { ... }` in the schema.


https://github.com/user-attachments/assets/8193af92-4a01-477a-a258-9e10965d4b49

