### PR TITLE
Schema-aware autocomplete in @DgsData annotation strings

### DIFF
--- a/src/main/java/com/netflix/dgs/plugin/services/internal/GraphQLSchemaRegistry.java
+++ b/src/main/java/com/netflix/dgs/plugin/services/internal/GraphQLSchemaRegistry.java
@@ -95,11 +95,11 @@ public class GraphQLSchemaRegistry {
         TypeDefinitionRegistry registry = getRegistry(psiElement);
         Set<String> names = new LinkedHashSet<>();
         registry.types().forEach((name, def) -> {
-            if (def instanceof ObjectTypeDefinition) {
+            if (def instanceof ObjectTypeDefinition && !isIntrospectionName(name)) {
                 names.add(name);
             }
         });
-        names.addAll(registry.objectTypeExtensions().keySet());
+        registry.objectTypeExtensions().keySet().stream().filter(n -> !isIntrospectionName(n)).forEach(names::add);
         return new ArrayList<>(names);
     }
 
@@ -107,11 +107,11 @@ public class GraphQLSchemaRegistry {
         TypeDefinitionRegistry registry = getRegistry(psiElement);
         Set<String> names = new LinkedHashSet<>();
         registry.types().forEach((name, def) -> {
-            if (def instanceof InterfaceTypeDefinition) {
+            if (def instanceof InterfaceTypeDefinition && !isIntrospectionName(name)) {
                 names.add(name);
             }
         });
-        names.addAll(registry.interfaceTypeExtensions().keySet());
+        registry.interfaceTypeExtensions().keySet().stream().filter(n -> !isIntrospectionName(n)).forEach(names::add);
         return new ArrayList<>(names);
     }
 
@@ -119,11 +119,14 @@ public class GraphQLSchemaRegistry {
         TypeDefinitionRegistry registry = getRegistry(psiElement);
         Set<String> names = new LinkedHashSet<>();
         registry.types().forEach((name, def) -> {
-            if (def instanceof ObjectTypeDefinition && hasKeyDirective(((ObjectTypeDefinition) def).getDirectives())) {
+            if (def instanceof ObjectTypeDefinition
+                    && !isIntrospectionName(name)
+                    && hasKeyDirective(((ObjectTypeDefinition) def).getDirectives())) {
                 names.add(name);
             }
         });
         registry.objectTypeExtensions().forEach((name, exts) -> {
+            if (isIntrospectionName(name)) return;
             for (ObjectTypeExtensionDefinition ext : exts) {
                 if (hasKeyDirective(ext.getDirectives())) {
                     names.add(name);
@@ -132,6 +135,12 @@ public class GraphQLSchemaRegistry {
             }
         });
         return new ArrayList<>(names);
+    }
+
+    // GraphQL spec reserves names starting with "__" for introspection metadata
+    // (e.g., __Schema, __Type, __Directive). Filter them from user-facing completion.
+    private boolean isIntrospectionName(String name) {
+        return name != null && name.startsWith("__");
     }
 
     public List<FieldDefinition> fieldDefinitions(@NotNull PsiElement psiElement, @NotNull String typeName) {

--- a/src/main/java/com/netflix/dgs/plugin/services/internal/GraphQLSchemaRegistry.java
+++ b/src/main/java/com/netflix/dgs/plugin/services/internal/GraphQLSchemaRegistry.java
@@ -18,6 +18,7 @@ package com.netflix.dgs.plugin.services.internal;
 
 import com.intellij.lang.jsgraphql.schema.GraphQLSchemaProvider;
 import com.intellij.lang.jsgraphql.schema.GraphQLTypeDefinitionUtil;
+import com.intellij.lang.jsgraphql.types.language.Directive;
 import com.intellij.lang.jsgraphql.types.language.DirectiveDefinition;
 import com.intellij.lang.jsgraphql.types.language.FieldDefinition;
 import com.intellij.lang.jsgraphql.types.language.InterfaceTypeDefinition;
@@ -34,8 +35,12 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public class GraphQLSchemaRegistry {
 
@@ -84,6 +89,67 @@ public class GraphQLSchemaRegistry {
             return Optional.ofNullable(GraphQLTypeDefinitionUtil.findElement(interfaceType.get().getSourceLocation(), psiElement.getProject()));
         }
         return Optional.empty();
+    }
+
+    public List<String> objectTypeNames(@NotNull PsiElement psiElement) {
+        TypeDefinitionRegistry registry = getRegistry(psiElement);
+        Set<String> names = new LinkedHashSet<>();
+        registry.types().forEach((name, def) -> {
+            if (def instanceof ObjectTypeDefinition) {
+                names.add(name);
+            }
+        });
+        names.addAll(registry.objectTypeExtensions().keySet());
+        return new ArrayList<>(names);
+    }
+
+    public List<String> interfaceTypeNames(@NotNull PsiElement psiElement) {
+        TypeDefinitionRegistry registry = getRegistry(psiElement);
+        Set<String> names = new LinkedHashSet<>();
+        registry.types().forEach((name, def) -> {
+            if (def instanceof InterfaceTypeDefinition) {
+                names.add(name);
+            }
+        });
+        names.addAll(registry.interfaceTypeExtensions().keySet());
+        return new ArrayList<>(names);
+    }
+
+    public List<String> entityTypeNames(@NotNull PsiElement psiElement) {
+        TypeDefinitionRegistry registry = getRegistry(psiElement);
+        Set<String> names = new LinkedHashSet<>();
+        registry.types().forEach((name, def) -> {
+            if (def instanceof ObjectTypeDefinition && hasKeyDirective(((ObjectTypeDefinition) def).getDirectives())) {
+                names.add(name);
+            }
+        });
+        registry.objectTypeExtensions().forEach((name, exts) -> {
+            for (ObjectTypeExtensionDefinition ext : exts) {
+                if (hasKeyDirective(ext.getDirectives())) {
+                    names.add(name);
+                    break;
+                }
+            }
+        });
+        return new ArrayList<>(names);
+    }
+
+    public List<FieldDefinition> fieldDefinitions(@NotNull PsiElement psiElement, @NotNull String typeName) {
+        TypeDefinitionRegistry registry = getRegistry(psiElement);
+        Map<String, FieldDefinition> fields = new LinkedHashMap<>();
+        getTypeDefinitions(registry, typeName).forEach(def ->
+            def.getFieldDefinitions().forEach(f -> fields.putIfAbsent(f.getName(), f)));
+        Optional<InterfaceTypeDefinition> iface = getInterfaceTypeDefinition(registry, typeName);
+        iface.ifPresent(def -> def.getFieldDefinitions().forEach(f -> fields.putIfAbsent(f.getName(), f)));
+        List<InterfaceTypeExtensionDefinition> ifaceExts = registry.interfaceTypeExtensions().get(typeName);
+        if (ifaceExts != null) {
+            ifaceExts.forEach(ext -> ext.getFieldDefinitions().forEach(f -> fields.putIfAbsent(f.getName(), f)));
+        }
+        return new ArrayList<>(fields.values());
+    }
+
+    private boolean hasKeyDirective(List<Directive> directives) {
+        return directives.stream().anyMatch(d -> "key".equals(d.getName()));
     }
 
     public Optional<PsiElement> psiForDirective(@NotNull PsiElement psiElement, @NotNull String name) {

--- a/src/main/kotlin/com/netflix/dgs/plugin/completion/DgsAnnotationCompletionContributor.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/completion/DgsAnnotationCompletionContributor.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.dgs.plugin.completion
+
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.lang.jsgraphql.icons.GraphQLIcons
+import com.intellij.lang.jsgraphql.types.schema.idl.TypeUtil
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiLiteralExpression
+import com.intellij.psi.PsiNameValuePair
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.ProcessingContext
+import com.netflix.dgs.plugin.DgsDataFetcher
+import com.netflix.dgs.plugin.DgsEntityFetcher
+import com.netflix.dgs.plugin.services.DgsService
+import com.netflix.dgs.plugin.services.internal.GraphQLSchemaRegistry
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.uast.UAnnotation
+import org.jetbrains.uast.evaluateString
+import org.jetbrains.uast.toUElement
+
+class DgsAnnotationCompletionContributor : CompletionContributor() {
+    init {
+        extend(
+            CompletionType.BASIC,
+            PlatformPatterns.psiElement().inside(PsiLiteralExpression::class.java),
+            DgsCompletionProvider
+        )
+        extend(
+            CompletionType.BASIC,
+            PlatformPatterns.psiElement().inside(KtStringTemplateExpression::class.java),
+            DgsCompletionProvider
+        )
+    }
+
+    private object DgsCompletionProvider : CompletionProvider<CompletionParameters>() {
+        override fun addCompletions(
+            parameters: CompletionParameters,
+            context: ProcessingContext,
+            result: CompletionResultSet
+        ) {
+            val position = parameters.position
+            val project = position.project
+
+            val dgsService = project.getService(DgsService::class.java)
+            if (!dgsService.isDgsProject(project)) return
+
+            val ctx = extractContext(position) ?: return
+            val uAnnotation = ctx.annotationPsi.toUElement() as? UAnnotation ?: return
+            if (!isDgsAnnotation(uAnnotation)) return
+
+            val registry = project.getService(GraphQLSchemaRegistry::class.java)
+
+            when (ctx.attrName) {
+                "parentType" -> {
+                    registry.objectTypeNames(position).forEach {
+                        result.addElement(LookupElementBuilder.create(it).withIcon(GraphQLIcons.Schema.Type))
+                    }
+                    registry.interfaceTypeNames(position).forEach {
+                        result.addElement(LookupElementBuilder.create(it).withIcon(GraphQLIcons.Schema.Interface))
+                    }
+                }
+                "name" -> {
+                    if (uAnnotation.qualifiedName == DGS_ENTITY_FETCHER_FQN) {
+                        registry.entityTypeNames(position).forEach {
+                            result.addElement(LookupElementBuilder.create(it).withIcon(GraphQLIcons.Schema.Type))
+                        }
+                    }
+                }
+                "field" -> {
+                    val parentType = resolveParentType(uAnnotation) ?: return
+                    registry.fieldDefinitions(position, parentType).forEach { f ->
+                        result.addElement(
+                            LookupElementBuilder.create(f.name)
+                                .withIcon(GraphQLIcons.Schema.Field)
+                                .withTypeText(TypeUtil.simplePrint(f.type))
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private data class AnnotationContext(val attrName: String, val annotationPsi: PsiElement)
+
+    companion object {
+        private const val DGS_ENTITY_FETCHER_FQN = "com.netflix.graphql.dgs.DgsEntityFetcher"
+
+        private fun extractContext(element: PsiElement): AnnotationContext? {
+            // Java
+            val javaPair = PsiTreeUtil.getParentOfType(element, PsiNameValuePair::class.java, false)
+            if (javaPair != null) {
+                val valueExpr = javaPair.value ?: return null
+                if (!PsiTreeUtil.isAncestor(valueExpr, element, false)) return null
+                val annotation = javaPair.parent?.parent ?: return null
+                return AnnotationContext(javaPair.name ?: "value", annotation)
+            }
+            // Kotlin
+            val ktArg = PsiTreeUtil.getParentOfType(element, KtValueArgument::class.java, false)
+            if (ktArg != null) {
+                val valueExpr = ktArg.getArgumentExpression() ?: return null
+                if (!PsiTreeUtil.isAncestor(valueExpr, element, false)) return null
+                val annotation = ktArg.parent?.parent ?: return null
+                val argName = ktArg.getArgumentName()?.asName?.identifier ?: "value"
+                return AnnotationContext(argName, annotation)
+            }
+            return null
+        }
+
+        private fun isDgsAnnotation(annotation: UAnnotation): Boolean =
+            DgsDataFetcher.isDataFetcherAnnotation(annotation) ||
+                DgsEntityFetcher.isEntityFetcherAnnotation(annotation)
+
+        private fun resolveParentType(annotation: UAnnotation): String? =
+            when (annotation.qualifiedName) {
+                "com.netflix.graphql.dgs.DgsQuery" -> "Query"
+                "com.netflix.graphql.dgs.DgsMutation" -> "Mutation"
+                "com.netflix.graphql.dgs.DgsSubscription" -> "Subscription"
+                else -> annotation.findAttributeValue("parentType")?.evaluateString()
+            }
+    }
+}

--- a/src/main/kotlin/com/netflix/dgs/plugin/completion/DgsAnnotationCompletionContributor.kt
+++ b/src/main/kotlin/com/netflix/dgs/plugin/completion/DgsAnnotationCompletionContributor.kt
@@ -21,6 +21,8 @@ import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.completion.PrioritizedLookupElement
+import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.lang.jsgraphql.icons.GraphQLIcons
 import com.intellij.lang.jsgraphql.types.schema.idl.TypeUtil
@@ -75,16 +77,16 @@ class DgsAnnotationCompletionContributor : CompletionContributor() {
             when (ctx.attrName) {
                 "parentType" -> {
                     registry.objectTypeNames(position).forEach {
-                        result.addElement(LookupElementBuilder.create(it).withIcon(GraphQLIcons.Schema.Type))
+                        result.addElement(boosted(LookupElementBuilder.create(it).withIcon(GraphQLIcons.Schema.Type)))
                     }
                     registry.interfaceTypeNames(position).forEach {
-                        result.addElement(LookupElementBuilder.create(it).withIcon(GraphQLIcons.Schema.Interface))
+                        result.addElement(boosted(LookupElementBuilder.create(it).withIcon(GraphQLIcons.Schema.Interface)))
                     }
                 }
                 "name" -> {
                     if (uAnnotation.qualifiedName == DGS_ENTITY_FETCHER_FQN) {
                         registry.entityTypeNames(position).forEach {
-                            result.addElement(LookupElementBuilder.create(it).withIcon(GraphQLIcons.Schema.Type))
+                            result.addElement(boosted(LookupElementBuilder.create(it).withIcon(GraphQLIcons.Schema.Type)))
                         }
                     }
                 }
@@ -92,9 +94,11 @@ class DgsAnnotationCompletionContributor : CompletionContributor() {
                     val parentType = resolveParentType(uAnnotation) ?: return
                     registry.fieldDefinitions(position, parentType).forEach { f ->
                         result.addElement(
-                            LookupElementBuilder.create(f.name)
-                                .withIcon(GraphQLIcons.Schema.Field)
-                                .withTypeText(TypeUtil.simplePrint(f.type))
+                            boosted(
+                                LookupElementBuilder.create(f.name)
+                                    .withIcon(GraphQLIcons.Schema.Field)
+                                    .withTypeText(TypeUtil.simplePrint(f.type))
+                            )
                         )
                     }
                 }
@@ -106,6 +110,12 @@ class DgsAnnotationCompletionContributor : CompletionContributor() {
 
     companion object {
         private const val DGS_ENTITY_FETCHER_FQN = "com.netflix.graphql.dgs.DgsEntityFetcher"
+
+        // Rank schema-aware items above IntelliJ's generic word/file completion.
+        private const val PRIORITY = 100.0
+
+        private fun boosted(element: LookupElement): LookupElement =
+            PrioritizedLookupElement.withPriority(element, PRIORITY)
 
         private fun extractContext(element: PsiElement): AnnotationContext? {
             // Java

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -56,6 +56,9 @@
 
         <gotoDeclarationHandler implementation="com.netflix.dgs.plugin.navigation.DgsAnnotationGotoDeclarationHandler"/>
 
+        <completion.contributor language="JAVA" implementationClass="com.netflix.dgs.plugin.completion.DgsAnnotationCompletionContributor"/>
+        <completion.contributor language="kotlin" implementationClass="com.netflix.dgs.plugin.completion.DgsAnnotationCompletionContributor"/>
+
         <implicitUsageProvider implementation="com.netflix.dgs.plugin.provider.DgsImplicitUsageProvider"/>
 
         <treeStructureProvider implementation="com.netflix.dgs.plugin.provider.DgsProjectStructureProvider"/>


### PR DESCRIPTION
## Summary

Adds schema-aware code completion inside the string values of DGS annotations (DgsData, DgsQuery, DgsMutation, DgsSubscription, DgsEntityFetcher). Completes parentType, field, and name against the actual GraphQL schema instead of the project word index.

1. Schema-aware lookup items now rank above IntelliJ's generic text and filesystem completion via PrioritizedLookupElement, so the relevant suggestions show up at the top of the popup.
2. The GraphQL introspection types (__Schema, __Type, __Directive, etc.) are filtered out, since they are spec-reserved metadata and never something a developer would write in a DGS annotation.

| Trigger | Suggestions |
|---|---|
| @DgsData(parentType = "<cursor>" | Object and interface type names from the schema |
| @DgsData(parentType = "Foo", field = "<cursor>" | Fields on Foo (including type extensions and interface fields) |
| @DgsQuery / @DgsMutation / @DgsSubscription (field = "<cursor>" | Fields on Query / Mutation / Subscription |
| @DgsEntityFetcher(name = "<cursor>" | Federation entity type names (types with @key) |

Reuses what is sensible from the underlying GraphQL plugin: 

- `GraphQLIcons.Schema` for lookup icons, 
- `TypeUtil.simplePrint `for tail text type rendering, and 
- `GraphQLSchemaProvider / TypeDefinitionRegistry` for schema traversal.

> Before
```
Before this change, typing inside a DGS annotation string surfaced IntelliJ's generic word completion, which offered every identifier and filename in the project regardless of whether it was a valid schema element.
```

> Now
```
Now the popup shows only the actual schema types and fields, scoped to the annotation and attribute under the cursor.
```

## Testing Done
- [x] Tested on Sandbox

> Parent Type
<img width="769" height="105" alt="image" src="https://github.com/user-attachments/assets/e099a129-02da-4cf8-b9dc-fe05824f479e" />

<br/><br/>

> Field Test
<img width="796" height="95" alt="image" src="https://github.com/user-attachments/assets/a5ef2760-d4bd-4662-a8fd-3799d5a64e1f" />

<br/><br/>

> DgsQuery
<img width="648" height="106" alt="image" src="https://github.com/user-attachments/assets/7c1fc854-eeb8-4f2d-ad66-6542baf15716" />

<br/><br/>

> DgsEntityFetcher
<img width="376" height="84" alt="image" src="https://github.com/user-attachments/assets/6b581e39-b2c7-4e10-a0d6-1243bbc6af6c" />

